### PR TITLE
Add prefetching of containment matches to speed up gather

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -18,9 +18,8 @@ outdir = config.get('outdir', 'outputs/')
 outdir = outdir.rstrip('/')
 ABUNDTRIM_MEMORY=40e9
 
-sourmash_db = config.get('db', 'all-gather-genomes.sbt.zip')   # CTB add to conf
-
-GATHER_CSV=f'{outdir}/genbank/{SAMPLE}.x.genbank.gather.csv'
+GENBANK_DB = glob.glob('/home/irber/sourmash_databases/outputs/sbt/genbank-*x1e5*k31*')
+GATHER_CSV = f'{outdir}/genbank/{SAMPLE}.x.genbank.gather.csv'
 
 genome_accs = []
 if os.path.exists(GATHER_CSV):
@@ -227,19 +226,6 @@ rule sourmash_reads_genbank:
            --name {wildcards.sra_id} --track-abundance
     """
 
-# wildcard rule for running sourmash gather on abundtrim read signature
-rule sourmash_gather_reads:
-    input:
-        sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
-        db = sourmash_db,
-    output:
-        csv = outdir + "/{sra_id}.gather.csv",
-        out = outdir + "/{sra_id}.gather.out",
-    conda: "env/sourmash.yml"
-    shell: """
-        sourmash gather {input.sig} {input.db} -o {output.csv} > {output.out}
-    """
-
 # NON-WILDCARD rule for configuring ipython kernel for papermill
 rule set_kernel:
     output:
@@ -307,16 +293,31 @@ rule map_leftover_reads:
     """
 
 # wildcard rule for running sourmash gather x genbank
-rule sourmash_gather_reads_genbank:
+rule prefetch_sourmash_gather_reads_genbank:
     input:
         sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
-        db = glob.glob('/home/irber/sourmash_databases/outputs/sbt/genbank-*x1e5*k31*')
+        db = GENBANK_DB,
     output:
-        csv = outdir + "/genbank/{sra_id}.x.genbank.gather.csv",
-        matches = outdir + "/genbank/{sra_id}.x.genbank.gather.sig",
+        matches = outdir + "/genbank/{sra_id}.x.genbank.prefetch.sig",
     conda: "env/sourmash.yml"
     shell: """
-        sourmash gather {input.sig} /home/ctbrown/genome-grist/all-gather-genomes.sbt.zip {input.db} -o {output.csv} --save-matches {output.matches}
+        python -m genome_grist.prefetch_gather --query {input.sig} \
+          --db {input.db} --save-matches {output.matches}
+    """
+
+# wildcard rule for running sourmash gather on abundtrim read signature
+rule sourmash_gather_reads:
+    input:
+        sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
+        db = outdir + "/genbank/{sra_id}.x.genbank.prefetch.sig",
+    output:
+        csv = outdir + "/genbank/{sra_id}.x.genbank.gather.csv",
+        matches = outdir + "/genbank/{sra_id}.x.genbank.matches.sig",
+        out = outdir + "/genbank/{sra_id}.x.genbank.gather.out",
+    conda: "env/sourmash.yml"
+    shell: """
+        sourmash gather {input.sig} {input.db} -o {output.csv} \
+          --save-amtches {output.matches} > {output.out}
     """
 
 # wildcard rule for extracting accessions from gather output

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -16,7 +16,7 @@ print(f'sample: {SAMPLE}')
 
 outdir = config.get('outdir', 'outputs/')
 outdir = outdir.rstrip('/')
-ABUNDTRIM_MEMORY=10e9
+ABUNDTRIM_MEMORY=40e9
 
 sourmash_db = config.get('db', 'all-gather-genomes.sbt.zip')   # CTB add to conf
 

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -317,7 +317,7 @@ rule sourmash_gather_reads:
     conda: "env/sourmash.yml"
     shell: """
         sourmash gather {input.sig} {input.db} -o {output.csv} \
-          --save-amtches {output.matches} > {output.out}
+          --save-matches {output.matches} > {output.out}
     """
 
 # wildcard rule for extracting accessions from gather output

--- a/genome_grist/prefetch_gather.py
+++ b/genome_grist/prefetch_gather.py
@@ -1,0 +1,73 @@
+#! /usr/bin/env python
+import sys
+import argparse
+import copy
+
+import sourmash
+from sourmash import sourmash_args
+from sourmash.logging import notify, error
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--db', nargs='+', action='append',
+                   help='one or more databases to use')
+    p.add_argument('--query', nargs='*', default=[], action='append',
+                   help='one or more signature files to use as queries')
+    p.add_argument('--save-matches', required=True)
+    p.add_argument('--output-unassigned')
+    p.add_argument('--threshold-bp', type=float, default=1e5)
+    args = p.parse_args()
+
+    # flatten --db and --query lists
+    args.db = [item for sublist in args.db for item in sublist]
+    args.query = [item for sublist in args.query for item in sublist]
+
+    # build one big query:
+    query_sigs = []
+    for query_file in args.query:
+        query_sigs.extend(sourmash_args.load_file_as_signatures(query_file,
+                                                                ksize=31))
+
+    mh = query_sigs[0].minhash
+    for query_sig in query_sigs[1:]:
+        mh += query_sig.minhash
+
+    unident_mh = copy.copy(mh)
+
+    notify(f'Loaded {len(mh.hashes)} hashes from {len(query_sigs)} query signatures.')
+
+    # iterate over signatures in one at a time
+    keep = []
+    n = 0
+    for db in args.db:
+        for sig in sourmash_args.load_file_as_signatures(db, ksize=31):
+            n += 1
+            common = mh.count_common(sig.minhash)
+            if common:
+                # check scaled...
+                if common * mh.scaled >= args.threshold_bp:
+                    keep.append(sig)
+                    unident_mh.remove_many(sig.minhash.hashes)
+
+            if n % 10 == 0:
+                notify(f'{n} searched, {len(keep)} matches.', end='\r')
+
+    notify(f'{n} searched, {len(keep)} matches.')
+
+    if keep and args.save_matches:
+        notify('saving all matches to "{}"', args.save_matches)
+        with sourmash_args.FileOutput(args.save_matches, 'wt') as fp:
+            sourmash.save_signatures(keep, fp)
+
+    if args.output_unassigned:
+        notify('saving unidentified hashes to "{}"', args.output_unassigned)
+        ss = sourmash.SourmashSignature(unident_mh)
+        with open(args.output_unassigned, 'wt') as fp:
+            sourmash.save_signatures([ ss ], fp)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/snakemake.slurm
+++ b/snakemake.slurm
@@ -3,7 +3,7 @@
 #SBATCH -J gather-paper            # name for job
 #SBATCH -N 1                   # one "node", or computer
 #SBATCH -n 1                   # one task for this node
-#SBATCH -c 4                  # cores per task
+#SBATCH -c 16                  # cores per task
 #SBATCH -t 2-0                 # ask for 2 days
 #SBATCH --mem=80000             # memory (30,000 mb = 30gb)
 #SBATCH --mail-type=ALL
@@ -25,11 +25,7 @@ set -x
 cd ~/genome-grist
 
 # run the snakemake!
-#python -m genome_grist run conf.yml -j 32 --use-conda -n
-#genome-grist run conf-HSMA33MX.yml -j 32
-#genome-grist run conf-SRR606249.yml outputs/leftover/depth/SRR606249.summary.csv
-genome-grist run conf.yml map_reads --config sample=p8808mo10
-genome-grist run conf.yml summarize --config sample=p8808mo10
+genome-grist process SRR4027592 gather_genbank summarize -j 16
 
 # print out various information about the job
 env | grep SLURM            # Print out values of the current jobs SLURM environment variables


### PR DESCRIPTION
Use a prefetch approach to speed up gather, per https://github.com/dib-lab/sourmash/issues/1226.

This will eventually be integrated into sourmash natively, but it's such a persistent problem for genome-grist that I'm integrating it here first!
