### PR TITLE
Use checkpoints to provide an end-to-end workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 dist/
 genome_grist.egg-info/
 genome_grist/version.py
+outputs.test.HSMA33MX/

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,8 @@ clean-test:
 	rm -fr outputs.test.HSMA33MX/
 
 test:
-	genome-grist run tests/test-data/HSMA33MX.conf trim_reads -j 8 -p
-	# have to run this w/o conda to take advantage of latest sourmash @CTB
-	genome-grist run tests/test-data/HSMA33MX.conf gather_genbank -j 8 -p --no-use-conda
-	genome-grist run tests/test-data/HSMA33MX.conf summarize -j 8 -p
-	genome-grist run tests/test-data/HSMA33MX.conf build_consensus -j 8 -p
-	genome-grist run tests/test-data/HSMA33MX.conf make_sgc_conf -p
+	genome-grist run tests/test-data/HSMA33MX.conf summarize make_sgc_conf -j 8 -p
+	genome-grist run tests/test-data/HSMA33MX.conf summarize make_sgc_conf -j 8 -p
 
 flakes:
 	flake8 --ignore=E501 genome_grist/ tests/

--- a/genome_grist/combine_csvs.py
+++ b/genome_grist/combine_csvs.py
@@ -1,0 +1,61 @@
+#! /usr/bin/env python
+"""
+Combine CSVs and sort by given field.
+"""
+import sys
+import argparse
+import csv
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--sort-by', default=None)
+    p.add_argument('--reverse', action='store_true')
+    p.add_argument('csvs', nargs='+')
+    args = p.parse_args()
+
+    first_csv = args.csvs[0]
+    csvs = args.csvs[1:]
+
+    rows = []
+    with open(first_csv, 'rt') as fp:
+        r = csv.DictReader(fp)
+        rows.extend(list(r))
+        fieldnames = r.fieldnames
+
+    if args.sort_by:
+        sort_by = args.sort_by
+    else:
+        sort_by = fieldnames[0]
+
+    try:
+        float(rows[0][sort_by])
+        key_fn = lambda x: float(x[sort_by])
+    except ValueError:
+        key_fn = lambda x: x[sort_by]
+
+    for csvfile in csvs:
+        with open(csvfile, 'rt') as fp:
+            r = csv.DictReader(fp)
+            if r.fieldnames != fieldnames:
+                diff = set(r.fieldnames) ^ set(fieldnames)
+                print(f"error! disjoint fieldnames b/t {first_csv} and {csvfile}: {str(diff)}", file=sys.stderr)
+                sys.exit(-1)
+
+            new_rows = list(r)
+            rows.extend(new_rows)
+
+    print(f'loaded {len(rows)} total. now sorting!', file=sys.stderr)
+
+    rows.sort(key=key_fn, reverse=args.reverse)
+
+    o = csv.DictWriter(sys.stdout, fieldnames)
+    o.writeheader()
+    for row in rows:
+        o.writerow(row)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -11,6 +11,8 @@
 
 import glob, os, csv
 
+genome_accs = []
+
 # we have "semi-wildcard" rules that depend on gather output only - they
 # all depend on having the GATHER_CSV present.
 SAMPLE=config['sample']
@@ -31,19 +33,6 @@ SOURMASH_COMPUTE_KSIZES = config.get('sourmash_compute_ksizes',
 SOURMASH_COMPUTE_SCALED = config.get('sourmash_scaled', '1000')
 
 GATHER_CSV = f'{outdir}/genbank/{SAMPLE}.x.genbank.gather.csv'
-
-genome_accs = []
-if os.path.exists(GATHER_CSV):
-    print(f'gather output {GATHER_CSV} exists!')
-    with open(GATHER_CSV, 'rt') as fp:
-       r = csv.DictReader(fp)
-       for row in r:
-           acc = row['name'].split(' ')[0]
-           genome_accs.append(acc)
-    print(f'loaded {len(genome_accs)} accessions from gather results.')
-else:
-    print(f'{GATHER_CSV} does not exist.')
-
 
 ###
 
@@ -69,56 +58,69 @@ rule smash_reads:
     input:
         url_file = f"{outdir}/sigs/{SAMPLE}.abundtrim.sig"
 
-rule gather_genbank:
+checkpoint gather_genbank:
     input:
         url_file = GATHER_CSV
+    output:
+        touch("foo")                      # @CTB
 
-if genome_accs:
-    rule download_matching_genomes:
-        input:
-            genome = expand(outdir + "/genomes/{acc}.fna.gz",
-                            acc=genome_accs)
+class Checkpoint_GatherResults:
+    def __init__(self, pattern):
+        self.pattern = pattern
 
-    rule map_reads:
-        input:
-            f"{outdir}/minimap/depth/{SAMPLE}.summary.csv",
-            f"{outdir}/leftover/depth/{SAMPLE}.summary.csv"
+    def get_genome_accs(self):
+        assert os.path.exists(GATHER_CSV)
+        print(f'gather output {GATHER_CSV} exists!')
 
-    rule build_consensus:
-        input:
-            expand(outdir + "/minimap/{s}.x.{g}.consensus.fa.gz",
-                   s=SAMPLE, g=genome_accs),
-            expand(outdir + "/leftover/{s}.x.{g}.consensus.fa.gz",
-                   s=SAMPLE, g=genome_accs)
+        genome_accs = []
+        with open(GATHER_CSV, 'rt') as fp:
+           r = csv.DictReader(fp)
+           for row in r:
+               acc = row['name'].split(' ')[0]
+               genome_accs.append(acc)
+        print(f'loaded {len(genome_accs)} accessions from gather results.')
 
-    rule summarize:
-        input:
-            outdir + f'/reports/report-{SAMPLE}.html'
+        return genome_accs
 
-    rule make_sgc_conf:
-        input:
-            outdir + f"/sgc/{SAMPLE}.conf"
-else:
-    def complain():
-        print("**")
-        print(f"** ERROR: {GATHER_CSV} does not exist - ")
-        print("** please run 'gather_genbank' first, to create it!")
-        print("**")
+    def __call__(self, w):
+        global checkpoints
 
-    rule download_matching_genomes:
-        run: complain()
+        print('XXX', repr(w))
 
-    rule map_reads:
-        run: complain()
+        # wait for the results of 'gather_genbank'; this will trigger
+        # exception until that rule has been run.
+        checkpoints.gather_genbank.get()
 
-    rule build_consensus:
-        run: complain()
+        print('XYZ')
 
-    rule summarize:
-        run: complain()
+        # parse hitlist_genomes,
+        genome_accs = self.get_genome_accs()
 
-    rule make_sgc_conf:
-        run: complain()
+        p = expand(self.pattern, acc=genome_accs, **w)
+        print(p)
+        return p
+
+rule download_matching_genomes:
+    input:
+        genome = Checkpoint_GatherResults(outdir + "/genomes/{acc}.fna.gz"),
+
+rule map_reads:
+    input:
+        f"{outdir}/minimap/depth/{SAMPLE}.summary.csv",
+        f"{outdir}/leftover/depth/{SAMPLE}.summary.csv"
+
+rule build_consensus:
+    input:
+        Checkpoint_GatherResults(outdir + f"/minimap/{SAMPLE}.x.{{acc}}.consensus.fa.gz"),
+        Checkpoint_GatherResults(outdir + f"/leftover/{SAMPLE}.x.{{acc}}.consensus.fa.gz"),
+
+rule summarize:
+    input:
+        outdir + f'/reports/report-{SAMPLE}.html'
+
+rule make_sgc_conf:
+    input:
+        outdir + f"/sgc/{SAMPLE}.conf"
 
 # print out the configuration
 rule showconf:
@@ -305,9 +307,9 @@ rule new_consensus:
 # SEMI-WILDCARD rule for summarize depth into a CSV
 rule summarize_samtools_depth:
     input:
-        expand(outdir + "/{{dir}}/depth/{s}.x.{g}.txt",
-               s=SAMPLE, g=genome_accs)
-    output: f"{outdir}/{{dir}}/depth/{SAMPLE}.summary.csv"
+        Checkpoint_GatherResults(outdir + f"/{{dir}}/depth/{SAMPLE}.x.{{acc}}.txt")
+    output:
+        f"{outdir}/{{dir}}/depth/{SAMPLE}.summary.csv"
     run:
         import pandas as pd
 

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -60,7 +60,7 @@ checkpoint gather_genbank:
     input:
         url_file = GATHER_CSV
     output:
-        touch("foo")                      # @CTB
+        touch(f"{outdir}/.gather.{SAMPLE}")   # checkpoints need an output ;)
 
 class Checkpoint_GatherResults:
     def __init__(self, pattern):
@@ -389,8 +389,7 @@ rule extract_leftover_reads:
         csv = GATHER_CSV,
         mapped = Checkpoint_GatherResults(f"{outdir}/minimap/{SAMPLE}.x.{{acc}}.mapped.fq.gz"),
     output:
-        expand(f"{outdir}/minimap/{SAMPLE}.x.{{acc}}.leftover.fq.gz",
-               acc=Checkpoint_GatherResults("").get_genome_accs)
+        touch(f"{outdir}/.leftover-reads.{SAMPLE}")
     conda: "env/sourmash.yml"
     params:
         outdir = outdir,
@@ -404,6 +403,7 @@ rule map_leftover_reads:
     input:
         all_csv = f"{outdir}/minimap/depth/{{sra_id}}.summary.csv",
         query = ancient(f"{outdir}/genomes/{{acc}}.fna.gz"),
+        leftover_reads_flag = touch(f"{outdir}/.leftover-reads.{SAMPLE}"),
         reads = outdir + "/minimap/{sra_id}.x.{acc}.leftover.fq.gz",
     output:
         bam=outdir + "/leftover/{sra_id}.x.{acc}.bam",

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -11,8 +11,6 @@
 
 import glob, os, csv
 
-genome_accs = []
-
 # we have "semi-wildcard" rules that depend on gather output only - they
 # all depend on having the GATHER_CSV present.
 SAMPLE=config['sample']
@@ -70,7 +68,6 @@ class Checkpoint_GatherResults:
 
     def get_genome_accs(self):
         assert os.path.exists(GATHER_CSV)
-        print(f'gather output {GATHER_CSV} exists!')
 
         genome_accs = []
         with open(GATHER_CSV, 'rt') as fp:
@@ -85,19 +82,14 @@ class Checkpoint_GatherResults:
     def __call__(self, w):
         global checkpoints
 
-        print('XXX', repr(w))
-
         # wait for the results of 'gather_genbank'; this will trigger
         # exception until that rule has been run.
         checkpoints.gather_genbank.get()
-
-        print('XYZ')
 
         # parse hitlist_genomes,
         genome_accs = self.get_genome_accs()
 
         p = expand(self.pattern, acc=genome_accs, **w)
-        print(p)
         return p
 
 rule download_matching_genomes:
@@ -395,11 +387,10 @@ rule make_notebook:
 rule extract_leftover_reads:
     input:
         csv = GATHER_CSV,
-        reads = expand(f"{outdir}/minimap/{SAMPLE}.x.{{acc}}.mapped.fq.gz",
-                       acc=genome_accs),
+        mapped = Checkpoint_GatherResults(f"{outdir}/minimap/{SAMPLE}.x.{{acc}}.mapped.fq.gz"),
     output:
         expand(f"{outdir}/minimap/{SAMPLE}.x.{{acc}}.leftover.fq.gz",
-               acc=genome_accs),
+               acc=Checkpoint_GatherResults("").get_genome_accs)
     conda: "env/sourmash.yml"
     params:
         outdir = outdir,
@@ -510,13 +501,11 @@ rule download_matching_genomes_one_by_one:
 rule create_sgc_conf_generic:
     input:
         csv = outdir + "/genbank/{sra_id}.x.genbank.gather.csv",
+        queries = Checkpoint_GatherResults(outdir + "/genomes/{acc}.fna.gz"),
     output:
         conf = outdir + "/sgc/{sra_id}.conf"
     run:
-        queries = []
-        for acc in genome_accs:
-            queries.append(outdir + f"/genomes/{acc}.fna.gz")
-        query_list = "\n- ".join(queries)
+        query_list = "\n- ".join(input.queries)
         with open(output.conf, 'wt') as fp:
            print(f"""\
 catlas_base: {wildcards.sra_id}

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -403,7 +403,7 @@ rule map_leftover_reads:
     input:
         all_csv = f"{outdir}/minimap/depth/{{sra_id}}.summary.csv",
         query = ancient(f"{outdir}/genomes/{{acc}}.fna.gz"),
-        leftover_reads_flag = touch(f"{outdir}/.leftover-reads.{SAMPLE}"),
+        leftover_reads_flag = f"{outdir}/.leftover-reads.{SAMPLE}",
         reads = outdir + "/minimap/{sra_id}.x.{acc}.leftover.fq.gz",
     output:
         bam=outdir + "/leftover/{sra_id}.x.{acc}.bam",

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -94,7 +94,7 @@ class Checkpoint_GatherResults:
 
 rule download_matching_genomes:
     input:
-        genome = Checkpoint_GatherResults(outdir + "/genomes/{acc}.fna.gz"),
+        genome = Checkpoint_GatherResults("genbank_genomes/{acc}_genomic.fna.gz"),
 
 rule map_reads:
     input:
@@ -131,7 +131,7 @@ rule zip:
     shell: """
         zip -r transfer.zip {outdir}/leftover/depth/*.summary.csv \
                 {outdir}/minimap/depth/*.summary.csv \
-                {outdir}/*.gather.csv {outdir}/genbank/*.csv
+                {outdir}/*.gather.csv
     """
 
 
@@ -209,7 +209,7 @@ rule kmer_trim_reads:
 # wildcard rule for mapping abundtrim reads and producing a bam
 rule minimap:
     input:
-        query = ancient(outdir + "/genomes/{acc}.fna.gz"),
+        query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
         metagenome = outdir + "/abundtrim/{sra_id}.abundtrim.fq.gz",
     output:
         bam = outdir + "/minimap/{sra_id}.x.{acc}.bam",
@@ -258,7 +258,7 @@ rule covered_regions:
 # wildcard rule for calculating SNPs/etc.
 rule mpileup:
     input:
-        query = ancient(outdir + "/genomes/{acc}.fna.gz"),
+        query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
         bam = outdir + "/{dir}/{sra_id}.x.{acc}.bam",
     output:
         bcf = outdir + "/{dir}/{sra_id}.x.{acc}.bcf",
@@ -278,7 +278,7 @@ rule mpileup:
 rule new_consensus:
     input:
         vcf = outdir + "/{dir}/{sra_id}.x.{acc}.vcf.gz",
-        query = ancient(outdir + "/genomes/{acc}.fna.gz"),
+        query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
         regions = outdir + "/{dir}/depth/{sra_id}.x.{acc}.regions.bed",
     output:
         mask = outdir + "/{dir}/{sra_id}.x.{acc}.mask.bed",
@@ -402,7 +402,7 @@ rule extract_leftover_reads:
 rule map_leftover_reads:
     input:
         all_csv = f"{outdir}/minimap/depth/{{sra_id}}.summary.csv",
-        query = ancient(f"{outdir}/genomes/{{acc}}.fna.gz"),
+        query = ancient(f"genbank_genomes/{{acc}}_genomic.fna.gz"),
         leftover_reads_flag = f"{outdir}/.leftover-reads.{SAMPLE}",
     output:
         bam=outdir + "/leftover/{sra_id}.x.{acc}.bam",
@@ -444,36 +444,6 @@ rule sourmash_gather_reads:
           --save-matches {output.matches} > {output.out}
     """
 
-# wildcard rule for extracting accessions from gather output
-rule extract_genome_accs_from_gather:
-    input:
-        csv = ancient(outdir + "/genbank/{sra_id}.x.genbank.gather.csv"),
-    output:
-        acc_file = outdir + "/genbank/{sra_id}.genomes.accs.txt"
-    run:
-        n = None
-        with open(output.acc_file, 'wt') as outfp:
-            with open(input.csv, 'rt') as infp:
-                r = csv.DictReader(infp)
-                for n, row in enumerate(r):
-                    acc = row['name'].split(' ')[0]
-                    print(acc, file=outfp)
-
-        if n is not None:
-            print(f'found {n+1} accessions in {input.csv}')
-              
-
-# wildcard rule for getting genome info (URL, name) from genbank
-rule get_matching_genome_info:
-    input:
-        acc_file = outdir + "/genbank/{sra_id}.genomes.accs.txt"
-    output:
-        info_file = outdir + "/genbank/{sra_id}.genomes.info.csv"
-    shell: """
-        python -m genome_grist.genbank_genomes {input.acc_file} \
-          -o {output.info_file}
-    """
-
 # download genbank genome details; make an info.csv file for entry.
 # @CTB
 rule make_genbank_info_csv_2:
@@ -510,34 +480,11 @@ rule download_matching_genomes_one_by_one_2:
                      outfp.write(content)
                      print(f"...wrote {len(content)} bytes to {output.genome}")
 
-# NON-WILDCARD/gather-dependent rule for downloading actual genomes
-rule download_matching_genomes_one_by_one:
-    input:
-        info_file = ancient(outdir + f"/genbank/{SAMPLE}.genomes.info.csv")
-    output:
-        genome = outdir + "/genomes/{acc}.fna.gz"
-    run:
-        with open(input.info_file, 'rt') as infp:
-            r = csv.DictReader(infp)
-            for row in r:
-                acc = row['acc']
-                if acc != wildcards.acc: continue
-                url = row['genome_url']
-                name = row['ncbi_tax_name']
-
-                print(f"downloading genome for acc {acc}/{name} from NCBI...")
-                with open(output.genome, 'wb') as outfp:
-                    with urllib.request.urlopen(url) as response:
-                        content = response.read()
-                        outfp.write(content)
-                        print(f"...wrote {len(content)} bytes to {output.genome}")
-
-
 # create a spacegraphcats config file
 rule create_sgc_conf_generic:
     input:
         csv = outdir + "/genbank/{sra_id}.x.genbank.gather.csv",
-        queries = Checkpoint_GatherResults(outdir + "/genomes/{acc}.fna.gz"),
+        queries = Checkpoint_GatherResults("genbank_genomes/{acc}_genomic.fna.gz"),
     output:
         conf = outdir + "/sgc/{sra_id}.conf"
     run:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -11,8 +11,6 @@
 
 import glob, os, csv
 
-# we have "semi-wildcard" rules that depend on gather output only - they
-# all depend on having the GATHER_CSV present.
 SAMPLE=config['sample']
 print(f'sample: {SAMPLE}')
 
@@ -135,7 +133,7 @@ rule zip:
     """
 
 
-# wildcard rule for downloading SRA IDs.
+# download SRA IDs.
 rule wc_download_sra:
     output:
         r1 = protected(outdir + "/raw/{sra_id}_1.fastq.gz"),
@@ -154,7 +152,7 @@ rule wc_download_sra:
                split-paired-reads.py --gzip -1 {output.r1} -2 {output.r2}
         '''
 
-# wildcard rule for computing sourmash signature from raw reads
+# compute sourmash signature from raw reads
 rule sourmash_reads_raw:
     input:
         r1 = outdir + "/raw/{sra_id}_1.fastq.gz",
@@ -171,7 +169,7 @@ rule sourmash_reads_raw:
            --name 'rawreads:{wildcards.sra_id}' --track-abundance
     """
 
-# wildcard rule for adapter trimming
+# adapter trimming
 rule adapter_trim:
     input:
         r1 = ancient(outdir + "/raw/{sample}_1.fastq.gz"),
@@ -190,7 +188,7 @@ rule adapter_trim:
              LEADING:2 TRAILING:2 SLIDINGWINDOW:4:2
     """
 
-# wildcard rule for k-mer abundance trimming
+# k-mer abundance trimming
 rule kmer_trim_reads:
     input: 
         r1 = ancient(outdir + "/trim/{sample}_R1.trim.fq.gz"), 
@@ -206,7 +204,7 @@ rule kmer_trim_reads:
                -o {output} --gzip
     """
 
-# wildcard rule for mapping abundtrim reads and producing a bam
+# map abundtrim reads and producing a bam
 rule minimap:
     input:
         query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
@@ -220,7 +218,7 @@ rule minimap:
             samtools view -b -F 4 - | samtools sort - > {output.bam}
     """
 
-# wildcard rule for extracting FASTQ from BAM
+# extract FASTQ from BAM
 rule samtools_fastq:
     input:
         bam = outdir + "/minimap/{bam}.bam",
@@ -232,7 +230,7 @@ rule samtools_fastq:
         samtools bam2fq {input.bam} | gzip > {output.mapped}
     """
 
-# wildcard rule for getting per-base depth information from BAM
+# get per-base depth information from BAM
 rule samtools_depth:
     input:
         bam = outdir + "/{dir}/{bam}.bam",
@@ -255,7 +253,7 @@ rule covered_regions:
             bedtools merge -d 5 -c 4 -o mean > {output.regions}
     """
 
-# wildcard rule for calculating SNPs/etc.
+# calculating SNPs/etc.
 rule mpileup:
     input:
         query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
@@ -274,7 +272,7 @@ rule mpileup:
         bcftools index {output.vcf}
     """
 
-# wildcard rule for building new consensus
+# build new consensus
 rule new_consensus:
     input:
         vcf = outdir + "/{dir}/{sra_id}.x.{acc}.vcf.gz",
@@ -296,7 +294,7 @@ rule new_consensus:
         rm $genomefile
     """
 
-# SEMI-WILDCARD rule for summarize depth into a CSV
+# summarize depth into a CSV
 rule summarize_samtools_depth:
     input:
         Checkpoint_GatherResults(outdir + f"/{{dir}}/depth/{SAMPLE}.x.{{acc}}.txt")
@@ -330,7 +328,7 @@ rule summarize_samtools_depth:
 
         pd.DataFrame(runs).T.to_csv(output[0])
 
-# wildcard rule for computing sourmash signature from abundtrim reads
+# compute sourmash signature from abundtrim reads
 rule sourmash_reads_abundtrim:
     input:
         metagenome = ancient(outdir + "/abundtrim/{sra_id}.abundtrim.fq.gz"),
@@ -346,7 +344,7 @@ rule sourmash_reads_abundtrim:
            --name {wildcards.sra_id} --track-abundance
     """
 
-# NON-WILDCARD rule for configuring ipython kernel for papermill
+# configure ipython kernel for papermill
 rule set_kernel:
     output:
         touch(f"{outdir}/.kernel.set")
@@ -357,13 +355,14 @@ rule set_kernel:
     """
 
 
-# NON-WILDCARD rule for papermill -> reporting notebook + html
+# papermill -> reporting notebook + html
 rule make_notebook:
     input:
         nb = 'genome_grist/notebooks/report-sample.ipynb',
         all_csv = f"{outdir}/minimap/depth/{SAMPLE}.summary.csv",
         depth_csv = f"{outdir}/leftover/depth/{SAMPLE}.summary.csv",
         gather_csv = GATHER_CSV,
+        genomes_info_csv = f"{outdir}/genbank/{SAMPLE}.genomes.info.csv",
         kernel_set = rules.set_kernel.output,
     output:
         nb = outdir + f'/reports/report-{SAMPLE}.ipynb',
@@ -381,7 +380,7 @@ rule make_notebook:
              --ExecutePreprocessor.kernel_name=genome_grist > {output.html}
     """
 
-# NON-WILDCARD rule for mapped reads to leftover reads
+# convert mapped reads to leftover reads
 # @CTB update subtract-gather to take sample ID as param
 # @CTB update for intersected/overlapping reads too
 rule extract_leftover_reads:
@@ -414,7 +413,7 @@ rule map_leftover_reads:
             samtools view -b -F 4 - | samtools sort - > {output.bam}
     """
 
-# wildcard rule for running sourmash gather x genbank
+# run sourmash gather x genbank
 rule prefetch_sourmash_gather_reads_genbank:
     input:
         sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
@@ -429,7 +428,7 @@ rule prefetch_sourmash_gather_reads_genbank:
           --db {input.db} --save-matches {output.matches} -k {params.ksize}
     """
 
-# wildcard rule for running sourmash gather on abundtrim read signature
+# run sourmash gather on abundtrim read signature
 rule sourmash_gather_reads:
     input:
         sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
@@ -445,8 +444,7 @@ rule sourmash_gather_reads:
     """
 
 # download genbank genome details; make an info.csv file for entry.
-# @CTB
-rule make_genbank_info_csv_2:
+rule make_genbank_info_csv:
     output:
         csvfile = 'genbank_genomes/{acc}.info.csv'
     conda: 'env/genbank.yml'
@@ -455,9 +453,18 @@ rule make_genbank_info_csv_2:
             --output {output.csvfile}
     """
 
+# combined info.csv
+rule make_combined_info_csv:
+    input:
+        Checkpoint_GatherResults('genbank_genomes/{acc}.info.csv')
+    output:
+        genomes_info_csv = f"{outdir}/genbank/{SAMPLE}.genomes.info.csv",
+    shell: """
+        python -m genome_grist.combine_csvs {input} > {output}
+    """
+
 # download actual genomes!
-# @CTB
-rule download_matching_genomes_one_by_one_2:
+rule download_matching_genomes_one_by_one:
      input:
          csvfile = ancient('genbank_genomes/{acc}.info.csv')
      output:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -474,6 +474,42 @@ rule get_matching_genome_info:
           -o {output.info_file}
     """
 
+# download genbank genome details; make an info.csv file for entry.
+# @CTB
+rule make_genbank_info_csv_2:
+    output:
+        csvfile = 'genbank_genomes/{acc}.info.csv'
+    conda: 'env/genbank.yml'
+    shell: """
+        python -m genome_grist.genbank_genomes {wildcards.acc} \
+            --output {output.csvfile}
+    """
+
+# download actual genomes!
+# @CTB
+rule download_matching_genomes_one_by_one_2:
+     input:
+         csvfile = ancient('genbank_genomes/{acc}.info.csv')
+     output:
+         genome = "genbank_genomes/{acc}_genomic.fna.gz"
+     run:
+         with open(input.csvfile, 'rt') as infp:
+             r = csv.DictReader(infp)
+             rows = list(r)
+             assert len(rows) == 1
+             row = rows[0]
+             acc = row['acc']
+             assert wildcards.acc.startswith(acc)
+             url = row['genome_url']
+             name = row['ncbi_tax_name']
+
+             print(f"downloading genome for acc {acc}/{name} from NCBI...")
+             with open(output.genome, 'wb') as outfp:
+                 with urllib.request.urlopen(url) as response:
+                     content = response.read()
+                     outfp.write(content)
+                     print(f"...wrote {len(content)} bytes to {output.genome}")
+
 # NON-WILDCARD/gather-dependent rule for downloading actual genomes
 rule download_matching_genomes_one_by_one:
     input:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -404,13 +404,13 @@ rule map_leftover_reads:
         all_csv = f"{outdir}/minimap/depth/{{sra_id}}.summary.csv",
         query = ancient(f"{outdir}/genomes/{{acc}}.fna.gz"),
         leftover_reads_flag = f"{outdir}/.leftover-reads.{SAMPLE}",
-        reads = outdir + "/minimap/{sra_id}.x.{acc}.leftover.fq.gz",
     output:
         bam=outdir + "/leftover/{sra_id}.x.{acc}.bam",
     conda: "env/minimap2.yml"
     threads: 4
     shell: """
-        minimap2 -ax sr -t {threads} {input.query} {input.reads} | \
+        minimap2 -ax sr -t {threads} {input.query} \
+     {outdir}/minimap/{wildcards.sra_id}.x.{wildcards.acc}.leftover.fq.gz | \
             samtools view -b -F 4 - | samtools sort - > {output.bam}
     """
 

--- a/genome_grist/conf/env/genbank.yml
+++ b/genome_grist/conf/env/genbank.yml
@@ -1,0 +1,8 @@
+# conda environment configuration for snakemake --use-conda
+channels:
+    - conda-forge
+    - bioconda
+    - defaults
+dependencies:
+    - python>=3.7,<3.8
+    - lxml=4.6.1

--- a/genome_grist/conf/env/sourmash.yml
+++ b/genome_grist/conf/env/sourmash.yml
@@ -4,7 +4,7 @@ channels:
  - defaults
 dependencies:
  - screed
- - pip
+ - pip=20.3.1
  - pip:
    - git+https://github.com/dib-lab/genome-grist.git#egg=genome-grist
    - sourmash==4.0.0a3

--- a/genome_grist/conf/env/sourmash.yml
+++ b/genome_grist/conf/env/sourmash.yml
@@ -8,3 +8,4 @@ dependencies:
  - pip
  - pip:
    - git+https://github.com/dib-lab/genome-grist.git#egg=genome-grist
+   - sourmash==4.0.0a3

--- a/genome_grist/conf/env/sourmash.yml
+++ b/genome_grist/conf/env/sourmash.yml
@@ -3,7 +3,6 @@ channels:
  - bioconda
  - defaults
 dependencies:
- - sourmash>=3.5,<4
  - screed
  - pip
  - pip:


### PR DESCRIPTION
This PR introduces snakemake checkpoints into genome-grist to make all the rules run end-to-end. Also adds some other cleanup/streamlining.

Specifically,
* use the checkpoint-class-style hack I introduced in charcoal in https://github.com/dib-lab/charcoal/pull/163 to get the genome accessions from gather
* updates the sourmash environment with 4.0.0a3 wheel, for now

TODO:
- [x] refactor the genbank genome download & info stuff as in charcoal
