### PR TITLE
Allow input samples to be a list

### DIFF
--- a/genome_grist/__main__.py
+++ b/genome_grist/__main__.py
@@ -33,6 +33,10 @@ def run_snakemake(
     # basic command
     cmd = ["snakemake", "-s", snakefile]
 
+    # snakemake sometimes seems to want a default -j; set it to 1 for now.
+    # can overridden later on command line.
+    cmd += ["-j", "1"]
+
     # add --use-conda
     if not no_use_conda:
         cmd += ["--use-conda"]
@@ -47,10 +51,6 @@ def run_snakemake(
 
     if config_params:
         cmd += ["--config", *config_params]
-
-    # snakemake sometimes seems to want a default -j; set it to 1 for now.
-    # can overridden later on command line.
-    cmd += ["-j", "1"]
 
     # add configfile - try looking for it a few different ways.
     configfiles = [

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -416,7 +416,7 @@ rule map_leftover_reads:
             samtools view -b -F 4 - | samtools sort - > {output.bam}
     """
 
-# run sourmash gather x genbank
+# run sourmash search x genbank and find anything matching.
 rule prefetch_sourmash_gather_reads_genbank:
     input:
         sig = outdir + "/sigs/{sample}.abundtrim.sig",
@@ -431,7 +431,7 @@ rule prefetch_sourmash_gather_reads_genbank:
           --db {input.db} --save-matches {output.matches} -k {params.ksize}
     """
 
-# run sourmash gather on abundtrim read signature
+# run sourmash gather on prefetched reads
 rule sourmash_gather_reads:
     input:
         sig = outdir + "/sigs/{sample}.abundtrim.sig",

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -101,8 +101,8 @@ rule download_matching_genomes:
 
 rule map_reads:
     input:
-        f"{outdir}/minimap/depth/{{SAMPLE}}.summary.csv",
-        f"{outdir}/leftover/depth/{{SAMPLE}}.summary.csv"
+        expand(f"{outdir}/minimap/depth/{{SAMPLE}}.summary.csv", SAMPLE=SAMPLES),
+        expand(f"{outdir}/leftover/depth/{{SAMPLE}}.summary.csv", SAMPLE=SAMPLES)
 
 rule build_consensus:
     input:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -32,7 +32,6 @@ SOURMASH_COMPUTE_SCALED = config.get('sourmash_scaled', '1000')
 
 wildcard_constraints:
     size="\d+",
-    sra_id='[a-zA-Z0-9._-]+',                  # should be everything but /
     sample='[a-zA-Z0-9._-]+'                   # should be everything but /
 
 rule all:
@@ -140,8 +139,8 @@ rule zip:
 # download SRA IDs.
 rule wc_download_sra:
     output:
-        r1 = protected(outdir + "/raw/{sra_id}_1.fastq.gz"),
-        r2 = protected(outdir + "/raw/{sra_id}_2.fastq.gz"),
+        r1 = protected(outdir + "/raw/{sample}_1.fastq.gz"),
+        r2 = protected(outdir + "/raw/{sample}_2.fastq.gz"),
     conda: "env/sra.yml"
     shell: '''
         fastq-dump --skip-technical  \
@@ -151,7 +150,7 @@ rule wc_download_sra:
                --split-spot \
                --clip \
                -Z \
-               {wildcards.sra_id} | \
+               {wildcards.sample} | \
                perl -ne 's/\.([12]) /\/$1 /; print $_' | \
                split-paired-reads.py --gzip -1 {output.r1} -2 {output.r2}
         '''
@@ -159,10 +158,10 @@ rule wc_download_sra:
 # compute sourmash signature from raw reads
 rule sourmash_reads_raw:
     input:
-        r1 = outdir + "/raw/{sra_id}_1.fastq.gz",
-        r2 = outdir + "/raw/{sra_id}_2.fastq.gz",
+        r1 = outdir + "/raw/{sample}_1.fastq.gz",
+        r2 = outdir + "/raw/{sample}_2.fastq.gz",
     output:
-        sig = outdir + "/raw/{sra_id}.raw.sig"
+        sig = outdir + "/raw/{sample}.raw.sig"
     conda: "env/sourmash.yml"
     params:
         ksizes = ",".join([str(i) for i in SOURMASH_COMPUTE_KSIZES]),
@@ -170,7 +169,7 @@ rule sourmash_reads_raw:
     shell: """
         sourmash compute -k {params.ksizes} --scaled={params.scaled} \
            {input.r1} {input.r2} -o {output} \
-           --name 'rawreads:{wildcards.sra_id}' --track-abundance
+           --name 'rawreads:{wildcards.sample}' --track-abundance
     """
 
 # adapter trimming
@@ -212,9 +211,9 @@ rule kmer_trim_reads:
 rule minimap:
     input:
         query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
-        metagenome = outdir + "/abundtrim/{sra_id}.abundtrim.fq.gz",
+        metagenome = outdir + "/abundtrim/{sample}.abundtrim.fq.gz",
     output:
-        bam = outdir + "/minimap/{sra_id}.x.{acc}.bam",
+        bam = outdir + "/minimap/{sample}.x.{acc}.bam",
     conda: "env/minimap2.yml"
     threads: 4
     shell: """
@@ -261,11 +260,11 @@ rule covered_regions:
 rule mpileup:
     input:
         query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
-        bam = outdir + "/{dir}/{sra_id}.x.{acc}.bam",
+        bam = outdir + "/{dir}/{sample}.x.{acc}.bam",
     output:
-        bcf = outdir + "/{dir}/{sra_id}.x.{acc}.bcf",
-        vcf = outdir + "/{dir}/{sra_id}.x.{acc}.vcf.gz",
-        vcfi = outdir + "/{dir}/{sra_id}.x.{acc}.vcf.gz.csi",
+        bcf = outdir + "/{dir}/{sample}.x.{acc}.bcf",
+        vcf = outdir + "/{dir}/{sample}.x.{acc}.vcf.gz",
+        vcfi = outdir + "/{dir}/{sample}.x.{acc}.vcf.gz.csi",
     conda: "env/bcftools.yml"
     shell: """
         genomefile=$(mktemp -t grist.genome.XXXXXXX)
@@ -279,13 +278,13 @@ rule mpileup:
 # build new consensus
 rule new_consensus:
     input:
-        vcf = outdir + "/{dir}/{sra_id}.x.{acc}.vcf.gz",
+        vcf = outdir + "/{dir}/{sample}.x.{acc}.vcf.gz",
         query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
-        regions = outdir + "/{dir}/depth/{sra_id}.x.{acc}.regions.bed",
+        regions = outdir + "/{dir}/depth/{sample}.x.{acc}.regions.bed",
     output:
-        mask = outdir + "/{dir}/{sra_id}.x.{acc}.mask.bed",
-        genomefile = outdir + "/{dir}/{sra_id}.x.{acc}.fna.gz.sizes",
-        consensus = outdir + "/{dir}/{sra_id}.x.{acc}.consensus.fa.gz",
+        mask = outdir + "/{dir}/{sample}.x.{acc}.mask.bed",
+        genomefile = outdir + "/{dir}/{sample}.x.{acc}.fna.gz.sizes",
+        consensus = outdir + "/{dir}/{sample}.x.{acc}.consensus.fa.gz",
     conda: "env/bcftools.yml"
     shell: """
         genomefile=$(mktemp -t grist.genome.XXXXXXX)
@@ -311,7 +310,7 @@ rule summarize_samtools_depth:
         for n, sra_stat in enumerate(input):
             print(f'reading from {sra_stat} - {n+1}/{len(input)}...')
             data = pd.read_table(sra_stat, names=["contig", "pos", "coverage"])
-            sra_id = sra_stat.split("/")[-1].split(".")[0]
+            sample = sra_stat.split("/")[-1].split(".")[0]
             genome_id = sra_stat.split("/")[-1].split(".")[2]
 
             d = {}
@@ -327,7 +326,7 @@ rule summarize_samtools_depth:
                 d['unique_mapped_coverage'] = d['coverage']
             d['covered_bp'] = (1 - d['percent missed']/100.0) * d['genome bp']
             d['genome_id'] = genome_id
-            d['sample_id'] = sra_id
+            d['sample_id'] = sample
             runs[genome_id] = d
 
         pd.DataFrame(runs).T.to_csv(output[0])
@@ -335,9 +334,9 @@ rule summarize_samtools_depth:
 # compute sourmash signature from abundtrim reads
 rule sourmash_reads_abundtrim:
     input:
-        metagenome = ancient(outdir + "/abundtrim/{sra_id}.abundtrim.fq.gz"),
+        metagenome = ancient(outdir + "/abundtrim/{sample}.abundtrim.fq.gz"),
     output:
-        sig = outdir + "/sigs/{sra_id}.abundtrim.sig"
+        sig = outdir + "/sigs/{sample}.abundtrim.sig"
     conda: "env/sourmash.yml"
     params:
         ksizes = ",".join([str(i) for i in SOURMASH_COMPUTE_KSIZES]),
@@ -345,7 +344,7 @@ rule sourmash_reads_abundtrim:
     shell: """
         sourmash compute -k {params.ksizes} --scaled={params.scaled} \
            {input} -o {output} \
-           --name {wildcards.sra_id} --track-abundance
+           --name {wildcards.sample} --track-abundance
     """
 
 # configure ipython kernel for papermill
@@ -404,26 +403,26 @@ rule extract_leftover_reads:
 # rule for mapping leftover reads to genomes -> BAM
 rule map_leftover_reads:
     input:
-        all_csv = f"{outdir}/minimap/depth/{{sra_id}}.summary.csv",
+        all_csv = f"{outdir}/minimap/depth/{{sample}}.summary.csv",
         query = ancient(f"genbank_genomes/{{acc}}_genomic.fna.gz"),
-        leftover_reads_flag = f"{outdir}/.leftover-reads.{{sra_id}}",
+        leftover_reads_flag = f"{outdir}/.leftover-reads.{{sample}}",
     output:
-        bam=outdir + "/leftover/{sra_id}.x.{acc}.bam",
+        bam=outdir + "/leftover/{sample}.x.{acc}.bam",
     conda: "env/minimap2.yml"
     threads: 4
     shell: """
         minimap2 -ax sr -t {threads} {input.query} \
-     {outdir}/minimap/{wildcards.sra_id}.x.{wildcards.acc}.leftover.fq.gz | \
+     {outdir}/minimap/{wildcards.sample}.x.{wildcards.acc}.leftover.fq.gz | \
             samtools view -b -F 4 - | samtools sort - > {output.bam}
     """
 
 # run sourmash gather x genbank
 rule prefetch_sourmash_gather_reads_genbank:
     input:
-        sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
+        sig = outdir + "/sigs/{sample}.abundtrim.sig",
         db = SOURMASH_DB_LIST,
     output:
-        matches = outdir + "/genbank/{sra_id}.x.genbank.prefetch.sig",
+        matches = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
     conda: "env/sourmash.yml"
     params:
         ksize = SOURMASH_DB_KSIZE,
@@ -435,12 +434,12 @@ rule prefetch_sourmash_gather_reads_genbank:
 # run sourmash gather on abundtrim read signature
 rule sourmash_gather_reads:
     input:
-        sig = outdir + "/sigs/{sra_id}.abundtrim.sig",
-        db = outdir + "/genbank/{sra_id}.x.genbank.prefetch.sig",
+        sig = outdir + "/sigs/{sample}.abundtrim.sig",
+        db = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
     output:
-        csv = outdir + "/genbank/{sra_id}.x.genbank.gather.csv",
-        matches = outdir + "/genbank/{sra_id}.x.genbank.matches.sig",
-        out = outdir + "/genbank/{sra_id}.x.genbank.gather.out",
+        csv = outdir + "/genbank/{sample}.x.genbank.gather.csv",
+        matches = outdir + "/genbank/{sample}.x.genbank.matches.sig",
+        out = outdir + "/genbank/{sample}.x.genbank.gather.out",
     conda: "env/sourmash.yml"
     shell: """
         sourmash gather {input.sig} {input.db} -o {output.csv} \

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -11,8 +11,8 @@
 
 import glob, os, csv
 
-SAMPLE=config['sample']
-print(f'sample: {SAMPLE}')
+SAMPLES=config['sample']
+print(f'sample: {SAMPLES}')
 
 outdir = config.get('outdir', 'outputs/')
 outdir = outdir.rstrip('/')
@@ -28,52 +28,57 @@ SOURMASH_COMPUTE_KSIZES = config.get('sourmash_compute_ksizes',
                                      ['21', '31',' 51'])
 SOURMASH_COMPUTE_SCALED = config.get('sourmash_scaled', '1000')
 
-GATHER_CSV = f'{outdir}/genbank/{SAMPLE}.x.genbank.gather.csv'
+#GATHER_CSV = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv'
 
 ###
 
 wildcard_constraints:
     size="\d+",
-    sra_id='[a-zA-Z0-9._-]+'                   # should be everything but /
+    sra_id='[a-zA-Z0-9._-]+',                  # should be everything but /
+    SAMPLE='[a-zA-Z0-9._-]+'                   # should be everything but /
 
 rule all:
     input:
-        GATHER_CSV
+        expand(f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv',
+               SAMPLE=SAMPLES)
 
 rule download_reads:
     input:
-        f"{outdir}/raw/{SAMPLE}_1.fastq.gz",
-        f"{outdir}/raw/{SAMPLE}_2.fastq.gz",
-        f"{outdir}/raw/{SAMPLE}.raw.sig",
+        expand(f"{outdir}/raw/{{SAMPLE}}_1.fastq.gz", SAMPLE=SAMPLES),
+        expand(f"{outdir}/raw/{{SAMPLE}}_2.fastq.gz", SAMPLE=SAMPLES),
+        expand(f"{outdir}/raw/{{SAMPLE}}.raw.sig", SAMPLE=SAMPLES),
 
 rule trim_reads:
     input:
-        url_file = f"{outdir}/abundtrim/{SAMPLE}.abundtrim.fq.gz"
+        url_file = expand(f"{outdir}/abundtrim/{{SAMPLE}}.abundtrim.fq.gz",
+                          SAMPLE=SAMPLES)
 
 rule smash_reads:
     input:
-        url_file = f"{outdir}/sigs/{SAMPLE}.abundtrim.sig"
+        url_file = expand(f"{outdir}/sigs/{{SAMPLE}}.abundtrim.sig",
+                          SAMPLE=SAMPLES)
 
 checkpoint gather_genbank:
     input:
-        url_file = GATHER_CSV
+        gather_csv = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv'
     output:
-        touch(f"{outdir}/.gather.{SAMPLE}")   # checkpoints need an output ;)
+        touch(f"{outdir}/.gather.{{SAMPLE}}")   # checkpoints need an output ;)
 
 class Checkpoint_GatherResults:
     def __init__(self, pattern):
         self.pattern = pattern
 
-    def get_genome_accs(self):
-        assert os.path.exists(GATHER_CSV)
+    def get_genome_accs(self, sample):
+        gather_csv = f'{outdir}/genbank/{sample}.x.genbank.gather.csv'
+        assert os.path.exists(gather_csv)
 
         genome_accs = []
-        with open(GATHER_CSV, 'rt') as fp:
+        with open(gather_csv, 'rt') as fp:
            r = csv.DictReader(fp)
            for row in r:
                acc = row['name'].split(' ')[0]
                genome_accs.append(acc)
-        print(f'loaded {len(genome_accs)} accessions from gather results.')
+        print(f'loaded {len(genome_accs)} accessions from gather results in {gather_csv}.')
 
         return genome_accs
 
@@ -82,10 +87,10 @@ class Checkpoint_GatherResults:
 
         # wait for the results of 'gather_genbank'; this will trigger
         # exception until that rule has been run.
-        checkpoints.gather_genbank.get()
+        checkpoints.gather_genbank.get(**w)
 
         # parse hitlist_genomes,
-        genome_accs = self.get_genome_accs()
+        genome_accs = self.get_genome_accs(w.SAMPLE)
 
         p = expand(self.pattern, acc=genome_accs, **w)
         return p
@@ -96,21 +101,22 @@ rule download_matching_genomes:
 
 rule map_reads:
     input:
-        f"{outdir}/minimap/depth/{SAMPLE}.summary.csv",
-        f"{outdir}/leftover/depth/{SAMPLE}.summary.csv"
+        f"{outdir}/minimap/depth/{{SAMPLE}}.summary.csv",
+        f"{outdir}/leftover/depth/{{SAMPLE}}.summary.csv"
 
 rule build_consensus:
     input:
-        Checkpoint_GatherResults(outdir + f"/minimap/{SAMPLE}.x.{{acc}}.consensus.fa.gz"),
-        Checkpoint_GatherResults(outdir + f"/leftover/{SAMPLE}.x.{{acc}}.consensus.fa.gz"),
+        Checkpoint_GatherResults(outdir + f"/minimap/{{SAMPLE}}.x.{{acc}}.consensus.fa.gz"),
+        Checkpoint_GatherResults(outdir + f"/leftover/{{SAMPLE}}.x.{{acc}}.consensus.fa.gz"),
 
 rule summarize:
     input:
-        outdir + f'/reports/report-{SAMPLE}.html'
+        expand(f'{outdir}/reports/report-{{SAMPLE}}.html',
+               SAMPLE=SAMPLES)
 
 rule make_sgc_conf:
     input:
-        outdir + f"/sgc/{SAMPLE}.conf"
+        expand(f"{outdir}/sgc/{{SAMPLE}}.conf", SAMPLE=SAMPLES)
 
 # print out the configuration
 rule showconf:
@@ -297,9 +303,9 @@ rule new_consensus:
 # summarize depth into a CSV
 rule summarize_samtools_depth:
     input:
-        Checkpoint_GatherResults(outdir + f"/{{dir}}/depth/{SAMPLE}.x.{{acc}}.txt")
+        Checkpoint_GatherResults(outdir + f"/{{dir}}/depth/{{SAMPLE}}.x.{{acc}}.txt")
     output:
-        f"{outdir}/{{dir}}/depth/{SAMPLE}.summary.csv"
+        f"{outdir}/{{dir}}/depth/{{SAMPLE}}.summary.csv"
     run:
         import pandas as pd
 
@@ -359,21 +365,21 @@ rule set_kernel:
 rule make_notebook:
     input:
         nb = 'genome_grist/notebooks/report-sample.ipynb',
-        all_csv = f"{outdir}/minimap/depth/{SAMPLE}.summary.csv",
-        depth_csv = f"{outdir}/leftover/depth/{SAMPLE}.summary.csv",
-        gather_csv = GATHER_CSV,
-        genomes_info_csv = f"{outdir}/genbank/{SAMPLE}.genomes.info.csv",
+        all_csv = f"{outdir}/minimap/depth/{{SAMPLE}}.summary.csv",
+        depth_csv = f"{outdir}/leftover/depth/{{SAMPLE}}.summary.csv",
+        gather_csv = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv',
+        genomes_info_csv = f"{outdir}/genbank/{{SAMPLE}}.genomes.info.csv",
         kernel_set = rules.set_kernel.output,
     output:
-        nb = outdir + f'/reports/report-{SAMPLE}.ipynb',
-        html = outdir + f'/reports/report-{SAMPLE}.html',
+        nb = outdir + f'/reports/report-{{SAMPLE}}.ipynb',
+        html = outdir + f'/reports/report-{{SAMPLE}}.html',
     params:
         cwd = outdir + '/reports/',
         outdir = outdir,
     conda: 'env/papermill.yml'
     shell: """
         papermill {input.nb} - -k genome_grist \
-              -p sample_id {SAMPLE:q} -p render '' -p outdir {outdir:q}\
+              -p sample_id {wildcards.SAMPLE:q} -p render '' -p outdir {outdir:q}\
               --cwd {params.cwd} \
               > {output.nb}
         python -m nbconvert {output.nb} --to html --stdout --no-input \
@@ -385,10 +391,10 @@ rule make_notebook:
 # @CTB update for intersected/overlapping reads too
 rule extract_leftover_reads:
     input:
-        csv = GATHER_CSV,
-        mapped = Checkpoint_GatherResults(f"{outdir}/minimap/{SAMPLE}.x.{{acc}}.mapped.fq.gz"),
+        csv = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv',
+        mapped = Checkpoint_GatherResults(f"{outdir}/minimap/{{SAMPLE}}.x.{{acc}}.mapped.fq.gz"),
     output:
-        touch(f"{outdir}/.leftover-reads.{SAMPLE}")
+        touch(f"{outdir}/.leftover-reads.{{SAMPLE}}")
     conda: "env/sourmash.yml"
     params:
         outdir = outdir,
@@ -402,7 +408,7 @@ rule map_leftover_reads:
     input:
         all_csv = f"{outdir}/minimap/depth/{{sra_id}}.summary.csv",
         query = ancient(f"genbank_genomes/{{acc}}_genomic.fna.gz"),
-        leftover_reads_flag = f"{outdir}/.leftover-reads.{SAMPLE}",
+        leftover_reads_flag = f"{outdir}/.leftover-reads.{{sra_id}}",
     output:
         bam=outdir + "/leftover/{sra_id}.x.{acc}.bam",
     conda: "env/minimap2.yml"
@@ -458,7 +464,7 @@ rule make_combined_info_csv:
     input:
         Checkpoint_GatherResults('genbank_genomes/{acc}.info.csv')
     output:
-        genomes_info_csv = f"{outdir}/genbank/{SAMPLE}.genomes.info.csv",
+        genomes_info_csv = f"{outdir}/genbank/{{SAMPLE}}.genomes.info.csv",
     shell: """
         python -m genome_grist.combine_csvs {input} > {output}
     """
@@ -490,17 +496,17 @@ rule download_matching_genomes_one_by_one:
 # create a spacegraphcats config file
 rule create_sgc_conf_generic:
     input:
-        csv = outdir + "/genbank/{sra_id}.x.genbank.gather.csv",
+        csv = outdir + "/genbank/{SAMPLE}.x.genbank.gather.csv",
         queries = Checkpoint_GatherResults("genbank_genomes/{acc}_genomic.fna.gz"),
     output:
-        conf = outdir + "/sgc/{sra_id}.conf"
+        conf = outdir + "/sgc/{SAMPLE}.conf"
     run:
         query_list = "\n- ".join(input.queries)
         with open(output.conf, 'wt') as fp:
            print(f"""\
-catlas_base: {wildcards.sra_id}
+catlas_base: {wildcards.SAMPLE}
 input_sequences:
-- {outdir}/abundtrim/{wildcards.sra_id}.abundtrim.fq.gz
+- {outdir}/abundtrim/{wildcards.SAMPLE}.abundtrim.fq.gz
 ksize: 31
 radius: 1
 search:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -33,34 +33,34 @@ SOURMASH_COMPUTE_SCALED = config.get('sourmash_scaled', '1000')
 wildcard_constraints:
     size="\d+",
     sra_id='[a-zA-Z0-9._-]+',                  # should be everything but /
-    SAMPLE='[a-zA-Z0-9._-]+'                   # should be everything but /
+    sample='[a-zA-Z0-9._-]+'                   # should be everything but /
 
 rule all:
     input:
-        expand(f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv',
-               SAMPLE=SAMPLES)
+        expand(f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv',
+               sample=SAMPLES)
 
 rule download_reads:
     input:
-        expand(f"{outdir}/raw/{{SAMPLE}}_1.fastq.gz", SAMPLE=SAMPLES),
-        expand(f"{outdir}/raw/{{SAMPLE}}_2.fastq.gz", SAMPLE=SAMPLES),
-        expand(f"{outdir}/raw/{{SAMPLE}}.raw.sig", SAMPLE=SAMPLES),
+        expand(f"{outdir}/raw/{{sample}}_1.fastq.gz", sample=SAMPLES),
+        expand(f"{outdir}/raw/{{sample}}_2.fastq.gz", sample=SAMPLES),
+        expand(f"{outdir}/raw/{{sample}}.raw.sig", sample=SAMPLES),
 
 rule trim_reads:
     input:
-        url_file = expand(f"{outdir}/abundtrim/{{SAMPLE}}.abundtrim.fq.gz",
-                          SAMPLE=SAMPLES)
+        url_file = expand(f"{outdir}/abundtrim/{{sample}}.abundtrim.fq.gz",
+                          sample=SAMPLES)
 
 rule smash_reads:
     input:
-        url_file = expand(f"{outdir}/sigs/{{SAMPLE}}.abundtrim.sig",
-                          SAMPLE=SAMPLES)
+        url_file = expand(f"{outdir}/sigs/{{sample}}.abundtrim.sig",
+                          sample=SAMPLES)
 
 checkpoint gather_genbank:
     input:
-        gather_csv = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv'
+        gather_csv = f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv'
     output:
-        touch(f"{outdir}/.gather.{{SAMPLE}}")   # checkpoints need an output ;)
+        touch(f"{outdir}/.gather.{{sample}}")   # checkpoints need an output ;)
 
 class Checkpoint_GatherResults:
     def __init__(self, pattern):
@@ -88,7 +88,7 @@ class Checkpoint_GatherResults:
         checkpoints.gather_genbank.get(**w)
 
         # parse hitlist_genomes,
-        genome_accs = self.get_genome_accs(w.SAMPLE)
+        genome_accs = self.get_genome_accs(w.sample)
 
         p = expand(self.pattern, acc=genome_accs, **w)
         return p
@@ -99,22 +99,22 @@ rule download_matching_genomes:
 
 rule map_reads:
     input:
-        expand(f"{outdir}/minimap/depth/{{SAMPLE}}.summary.csv", SAMPLE=SAMPLES),
-        expand(f"{outdir}/leftover/depth/{{SAMPLE}}.summary.csv", SAMPLE=SAMPLES)
+        expand(f"{outdir}/minimap/depth/{{sample}}.summary.csv", sample=SAMPLES),
+        expand(f"{outdir}/leftover/depth/{{sample}}.summary.csv", sample=SAMPLES)
 
 rule build_consensus:
     input:
-        Checkpoint_GatherResults(outdir + f"/minimap/{{SAMPLE}}.x.{{acc}}.consensus.fa.gz"),
-        Checkpoint_GatherResults(outdir + f"/leftover/{{SAMPLE}}.x.{{acc}}.consensus.fa.gz"),
+        Checkpoint_GatherResults(outdir + f"/minimap/{{sample}}.x.{{acc}}.consensus.fa.gz"),
+        Checkpoint_GatherResults(outdir + f"/leftover/{{sample}}.x.{{acc}}.consensus.fa.gz"),
 
 rule summarize:
     input:
-        expand(f'{outdir}/reports/report-{{SAMPLE}}.html',
-               SAMPLE=SAMPLES)
+        expand(f'{outdir}/reports/report-{{sample}}.html',
+               sample=SAMPLES)
 
 rule make_sgc_conf:
     input:
-        expand(f"{outdir}/sgc/{{SAMPLE}}.conf", SAMPLE=SAMPLES)
+        expand(f"{outdir}/sgc/{{sample}}.conf", sample=SAMPLES)
 
 # print out the configuration
 rule showconf:
@@ -301,9 +301,9 @@ rule new_consensus:
 # summarize depth into a CSV
 rule summarize_samtools_depth:
     input:
-        Checkpoint_GatherResults(outdir + f"/{{dir}}/depth/{{SAMPLE}}.x.{{acc}}.txt")
+        Checkpoint_GatherResults(outdir + f"/{{dir}}/depth/{{sample}}.x.{{acc}}.txt")
     output:
-        f"{outdir}/{{dir}}/depth/{{SAMPLE}}.summary.csv"
+        f"{outdir}/{{dir}}/depth/{{sample}}.summary.csv"
     run:
         import pandas as pd
 
@@ -363,21 +363,21 @@ rule set_kernel:
 rule make_notebook:
     input:
         nb = 'genome_grist/notebooks/report-sample.ipynb',
-        all_csv = f"{outdir}/minimap/depth/{{SAMPLE}}.summary.csv",
-        depth_csv = f"{outdir}/leftover/depth/{{SAMPLE}}.summary.csv",
-        gather_csv = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv',
-        genomes_info_csv = f"{outdir}/genbank/{{SAMPLE}}.genomes.info.csv",
+        all_csv = f"{outdir}/minimap/depth/{{sample}}.summary.csv",
+        depth_csv = f"{outdir}/leftover/depth/{{sample}}.summary.csv",
+        gather_csv = f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv',
+        genomes_info_csv = f"{outdir}/genbank/{{sample}}.genomes.info.csv",
         kernel_set = rules.set_kernel.output,
     output:
-        nb = outdir + f'/reports/report-{{SAMPLE}}.ipynb',
-        html = outdir + f'/reports/report-{{SAMPLE}}.html',
+        nb = outdir + f'/reports/report-{{sample}}.ipynb',
+        html = outdir + f'/reports/report-{{sample}}.html',
     params:
         cwd = outdir + '/reports/',
         outdir = outdir,
     conda: 'env/papermill.yml'
     shell: """
         papermill {input.nb} - -k genome_grist \
-              -p sample_id {wildcards.SAMPLE:q} -p render '' -p outdir {outdir:q}\
+              -p sample_id {wildcards.sample:q} -p render '' -p outdir {outdir:q}\
               --cwd {params.cwd} \
               > {output.nb}
         python -m nbconvert {output.nb} --to html --stdout --no-input \
@@ -389,10 +389,10 @@ rule make_notebook:
 # @CTB update for intersected/overlapping reads too
 rule extract_leftover_reads:
     input:
-        csv = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv',
-        mapped = Checkpoint_GatherResults(f"{outdir}/minimap/{{SAMPLE}}.x.{{acc}}.mapped.fq.gz"),
+        csv = f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv',
+        mapped = Checkpoint_GatherResults(f"{outdir}/minimap/{{sample}}.x.{{acc}}.mapped.fq.gz"),
     output:
-        touch(f"{outdir}/.leftover-reads.{{SAMPLE}}")
+        touch(f"{outdir}/.leftover-reads.{{sample}}")
     conda: "env/sourmash.yml"
     params:
         outdir = outdir,
@@ -462,7 +462,7 @@ rule make_combined_info_csv:
     input:
         Checkpoint_GatherResults('genbank_genomes/{acc}.info.csv')
     output:
-        genomes_info_csv = f"{outdir}/genbank/{{SAMPLE}}.genomes.info.csv",
+        genomes_info_csv = f"{outdir}/genbank/{{sample}}.genomes.info.csv",
     shell: """
         python -m genome_grist.combine_csvs {input} > {output}
     """
@@ -494,17 +494,17 @@ rule download_matching_genomes_one_by_one:
 # create a spacegraphcats config file
 rule create_sgc_conf_generic:
     input:
-        csv = outdir + "/genbank/{SAMPLE}.x.genbank.gather.csv",
+        csv = outdir + "/genbank/{sample}.x.genbank.gather.csv",
         queries = Checkpoint_GatherResults("genbank_genomes/{acc}_genomic.fna.gz"),
     output:
-        conf = outdir + "/sgc/{SAMPLE}.conf"
+        conf = outdir + "/sgc/{sample}.conf"
     run:
         query_list = "\n- ".join(input.queries)
         with open(output.conf, 'wt') as fp:
            print(f"""\
-catlas_base: {wildcards.SAMPLE}
+catlas_base: {wildcards.sample}
 input_sequences:
-- {outdir}/abundtrim/{wildcards.SAMPLE}.abundtrim.fq.gz
+- {outdir}/abundtrim/{wildcards.sample}.abundtrim.fq.gz
 ksize: 31
 radius: 1
 search:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -431,10 +431,24 @@ rule prefetch_sourmash_gather_reads_genbank:
           --db {input.db} --save-matches {output.matches} -k {params.ksize}
     """
 
-# run sourmash gather on prefetched reads
-rule sourmash_gather_reads:
+# run sourmash search x genbank and find anything matching.
+rule split_read_signature_known_unknown:
     input:
         sig = outdir + "/sigs/{sample}.abundtrim.sig",
+        prefetch = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+    output:
+        known = outdir + "/genbank/{sample}.x.genbank.known.sig",
+        unknown = outdir + "/genbank/{sample}.x.genbank.unknown.sig",
+    conda: "env/sourmash.yml"
+    shell: """
+        python -m genome_grist.gather_split {input.sig} {input.prefetch} \
+          {output.known} {output.unknown}
+    """
+
+# run sourmash gather with known hashes on prefetched matches.
+rule sourmash_gather_reads:
+    input:
+        known = outdir + "/genbank/{sample}.x.genbank.known.sig",
         db = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
     output:
         csv = outdir + "/genbank/{sample}.x.genbank.gather.csv",
@@ -442,7 +456,7 @@ rule sourmash_gather_reads:
         out = outdir + "/genbank/{sample}.x.genbank.gather.out",
     conda: "env/sourmash.yml"
     shell: """
-        sourmash gather {input.sig} {input.db} -o {output.csv} \
+        sourmash gather {input.known} {input.db} -o {output.csv} \
           --save-matches {output.matches} > {output.out}
     """
 

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -55,6 +55,11 @@ rule smash_reads:
         url_file = expand(f"{outdir}/sigs/{{sample}}.abundtrim.sig",
                           sample=SAMPLES)
 
+rule prefetch_genbank:
+    input:
+        expand(outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+               sample=SAMPLES)
+
 checkpoint gather_genbank:
     input:
         gather_csv = f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv'

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -18,7 +18,7 @@ outdir = config.get('outdir', 'outputs/')
 outdir = outdir.rstrip('/')
 print('outdir:', outdir)
 
-ABUNDTRIM_MEMORY = config.get('metagenome_trim_memory', '1e9')
+ABUNDTRIM_MEMORY = float(config.get('metagenome_trim_memory', '1e9'))
 
 sourmash_db_pattern = config.get('sourmash_database_glob_pattern', 'MUST SPECIFY IN CONFIG')
 SOURMASH_DB_LIST = glob.glob(sourmash_db_pattern)
@@ -62,6 +62,11 @@ rule prefetch_genbank:
 
 checkpoint gather_genbank:
     input:
+        expand(f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv',
+               sample=SAMPLES)
+
+checkpoint gather_genbank_wc:
+    input:
         gather_csv = f'{outdir}/genbank/{{sample}}.x.genbank.gather.csv'
     output:
         touch(f"{outdir}/.gather.{{sample}}")   # checkpoints need an output ;)
@@ -87,9 +92,9 @@ class Checkpoint_GatherResults:
     def __call__(self, w):
         global checkpoints
 
-        # wait for the results of 'gather_genbank'; this will trigger
+        # wait for the results of 'gather_genbank_wc'; this will trigger
         # exception until that rule has been run.
-        checkpoints.gather_genbank.get(**w)
+        checkpoints.gather_genbank_wc.get(**w)
 
         # parse hitlist_genomes,
         genome_accs = self.get_genome_accs(w.sample)
@@ -147,6 +152,8 @@ rule wc_download_sra:
         r1 = protected(outdir + "/raw/{sample}_1.fastq.gz"),
         r2 = protected(outdir + "/raw/{sample}_2.fastq.gz"),
     conda: "env/sra.yml"
+    resources:
+        mem_mb=40000,
     shell: '''
         fastq-dump --skip-technical  \
                --readids \
@@ -204,6 +211,8 @@ rule kmer_trim_reads:
     output:
         protected(outdir + "/abundtrim/{sample}.abundtrim.fq.gz")
     conda: 'env/trim.yml'
+    resources:
+        mem_mb = int(ABUNDTRIM_MEMORY / 1e6),
     params:
         mem = ABUNDTRIM_MEMORY,
     shell: """
@@ -428,6 +437,8 @@ rule prefetch_sourmash_gather_reads_genbank:
         db = SOURMASH_DB_LIST,
     output:
         matches = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+    resources:
+        mem_mb=100000,
     conda: "env/sourmash.yml"
     params:
         ksize = SOURMASH_DB_KSIZE,

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -28,8 +28,6 @@ SOURMASH_COMPUTE_KSIZES = config.get('sourmash_compute_ksizes',
                                      ['21', '31',' 51'])
 SOURMASH_COMPUTE_SCALED = config.get('sourmash_scaled', '1000')
 
-#GATHER_CSV = f'{outdir}/genbank/{{SAMPLE}}.x.genbank.gather.csv'
-
 ###
 
 wildcard_constraints:
@@ -78,7 +76,7 @@ class Checkpoint_GatherResults:
            for row in r:
                acc = row['name'].split(' ')[0]
                genome_accs.append(acc)
-        print(f'loaded {len(genome_accs)} accessions from gather results in {gather_csv}.')
+        print(f'loaded {len(genome_accs)} accessions from {gather_csv}.')
 
         return genome_accs
 

--- a/genome_grist/gather_split.py
+++ b/genome_grist/gather_split.py
@@ -55,6 +55,9 @@ def main():
             keep.append(sig)
             unknown_mh.remove_many(db_mh.hashes)
 
+        if n % 100 == 0:
+            notify(f"{n} searched, {len(keep)} matches.", end="\r")
+
     notify(f"{n} searched, {len(keep)} matches.")
 
     known_mh = copy.copy(query_mh)

--- a/genome_grist/gather_split.py
+++ b/genome_grist/gather_split.py
@@ -60,8 +60,13 @@ def main():
 
     notify(f"{n} searched, {m} matches.")
 
-    known_mh = copy.copy(query_mh)
-    known_mh.remove_many(unknown_mh.hashes)
+    print('xxx', len(query_mh))
+    known_hashes = set(query_mh.hashes)
+    print('xyx', len(unknown_mh))
+    known_hashes -= set(unknown_mh.hashes)
+
+    known_mh = query_mh.copy_and_clear()
+    known_mh.add_many(known_hashes)
 
     p_known = len(known_mh) / len(query_mh) * 100
     print(f"{len(known_mh)} known hashes of {len(query_mh)} total ({p_known:.1f}% known, {100-p_known:.1f}% unknown).")

--- a/genome_grist/gather_split.py
+++ b/genome_grist/gather_split.py
@@ -1,0 +1,80 @@
+#! /usr/bin/env python
+"""
+For a signature and a set of matches from prefetch_gather, split the
+signature into a collection of known and unknown hashes.
+"""
+import sys
+import argparse
+import copy
+
+import sourmash
+from sourmash import sourmash_args
+from sourmash.logging import notify
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('query_file')
+    p.add_argument('matches_db')
+    p.add_argument('known_out')
+    p.add_argument('unknown_out')
+
+    p.add_argument("-k", "--ksize", type=int, default=31)
+    p.add_argument("--moltype", default="DNA")
+    args = p.parse_args()
+
+    ksize = args.ksize
+    moltype = args.moltype
+
+    # build one big query:
+    query_sig = sourmash_args.load_query_signature(args.query_file, ksize,
+                                                    moltype)
+
+    query_mh = query_sig.minhash
+
+    if not query_mh.scaled:
+        notify("ERROR: must use scaled signatures.")
+        sys.exit(-1)
+
+    unknown_mh = copy.copy(query_mh)
+
+    notify(f"Loaded {len(query_mh.hashes)} hashes from '{args.query_file}'")
+
+    # iterate over signatures in matches one at a time, for each db;
+    # find those with any kind of containment.
+    keep = []
+    n = 0
+    print(f"\nloading signatures from '{args.matches_db}'")
+    for sig in sourmash_args.load_file_as_signatures(args.matches_db,
+                                                     ksize=ksize,
+                                                     select_moltype=moltype):
+        n += 1
+        db_mh = sig.minhash.downsample(scaled=query_mh.scaled)
+        common = query_mh.count_common(db_mh)
+        if common:
+            keep.append(sig)
+            unknown_mh.remove_many(db_mh.hashes)
+
+    notify(f"{n} searched, {len(keep)} matches.")
+
+    known_mh = copy.copy(query_mh)
+    known_mh.remove_many(unknown_mh.hashes)
+
+    p_known = len(known_mh) / len(query_mh) * 100
+    print(f"{len(known_mh)} known hashes of {len(query_mh)} total ({p_known:.1f}% known, {100-p_known:.1f}% unknown).")
+
+    with sourmash_args.FileOutput(args.known_out, 'wt') as fp:
+        print(f"saving known hashes to '{args.known_out}'")
+        ss = sourmash.SourmashSignature(known_mh)
+        sourmash.save_signatures([ss], fp)
+
+    with sourmash_args.FileOutput(args.unknown_out, 'wt') as fp:
+        print(f"saving unknown hashes '{args.unknown_out}'")
+        ss = sourmash.SourmashSignature(unknown_mh)
+        sourmash.save_signatures([ss], fp)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/genome_grist/gather_split.py
+++ b/genome_grist/gather_split.py
@@ -42,7 +42,7 @@ def main():
 
     # iterate over signatures in matches one at a time, for each db;
     # find those with any kind of containment.
-    keep = []
+    m = 0
     n = 0
     print(f"\nloading signatures from '{args.matches_db}'")
     for sig in sourmash_args.load_file_as_signatures(args.matches_db,
@@ -50,15 +50,15 @@ def main():
                                                      select_moltype=moltype):
         n += 1
         db_mh = sig.minhash.downsample(scaled=query_mh.scaled)
-        common = query_mh.count_common(db_mh)
+        common = unknown_mh.count_common(db_mh)
         if common:
-            keep.append(sig)
+            m += 1
             unknown_mh.remove_many(db_mh.hashes)
 
         if n % 100 == 0:
-            notify(f"{n} searched, {len(keep)} matches.", end="\r")
+            notify(f"{n} searched, {m} matches.", end="\r")
 
-    notify(f"{n} searched, {len(keep)} matches.")
+    notify(f"{n} searched, {m} matches.")
 
     known_mh = copy.copy(query_mh)
     known_mh.remove_many(unknown_mh.hashes)

--- a/genome_grist/prefetch_gather.py
+++ b/genome_grist/prefetch_gather.py
@@ -1,4 +1,7 @@
 #! /usr/bin/env python
+"""
+Prefetch results from a large database, to then run gather on.
+"""
 import sys
 import argparse
 import copy
@@ -57,7 +60,8 @@ def main():
 
     notify(f"Loaded {len(mh.hashes)} hashes from {len(query_sigs)} query signatures.")
 
-    # iterate over signatures in one at a time
+    # iterate over signatures in db one at a time, for each db;
+    # find those with any kind of containment.
     keep = []
     n = 0
     for db in args.db:
@@ -68,7 +72,7 @@ def main():
             db_mh = sig.minhash.downsample(scaled=mh.scaled)
             common = mh.count_common(db_mh)
             if common:
-                # check scaled...
+                # check scaled here?
                 if common * mh.scaled >= args.threshold_bp:
                     keep.append(sig)
                     unident_mh.remove_many(db_mh.hashes)


### PR DESCRIPTION
This PR adjusts the Snakefile so that `sample` is now a wildcard, allowing multiple samples to be provided via config.

Among other things, this PR dramatically speeds up the actual sourmash gather step by running gather only on the known hashes.

Other updates and modifications:
- [x] add `mem_mb` resource specifications to memory intensive rules
- [x] merge `sra_id` and `sample` wildcards in Snakefile
- [x] fix `-j` command line parameter
- [x] add `prefetch_gather` postprocessing to split into known and unknown hashes ref #32

Closes #32