### PR TITLE
adjustments for virus and protein

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -444,7 +444,7 @@ rule prefetch_sourmash_gather_reads_genbank:
         ksize = SOURMASH_DB_KSIZE,
     shell: """
         python -m genome_grist.prefetch_gather --query {input.sig} \
-          --db {input.db} --save-matches {output.matches} -k {params.ksize}
+          --db {input.db} --save-matches {output.matches} -k {params.ksize} --threshold-bp=0
     """
 
 # run sourmash search x genbank and find anything matching.
@@ -473,6 +473,7 @@ rule sourmash_gather_reads:
     conda: "env/sourmash.yml"
     shell: """
         sourmash gather {input.known} {input.db} -o {output.csv} \
+          --threshold-bp 0 \
           --save-matches {output.matches} > {output.out}
     """
 

--- a/genome_grist/gather_split.py
+++ b/genome_grist/gather_split.py
@@ -21,6 +21,7 @@ def main():
 
     p.add_argument("-k", "--ksize", type=int, default=31)
     p.add_argument("--moltype", default="DNA")
+    p.add_argument("--scaled", default=None)
     args = p.parse_args()
 
     ksize = args.ksize
@@ -35,6 +36,11 @@ def main():
     if not query_mh.scaled:
         notify("ERROR: must use scaled signatures.")
         sys.exit(-1)
+
+    if args.scaled:
+        scaled = int(args.scaled)
+        notify(f"Downsampling query from scaled={query_mh.scaled} to {scaled}")
+        query_mh = query_mh.downsample(scaled=int(scaled))
 
     unknown_mh = copy.copy(query_mh)
 

--- a/genome_grist/prefetch_gather.py
+++ b/genome_grist/prefetch_gather.py
@@ -82,7 +82,7 @@ def main():
 
     notify(f"{n} searched, {len(keep)} matches.")
 
-    if keep and args.save_matches:
+    if args.save_matches:
         notify('saving all matches to "{}"', args.save_matches)
         with sourmash_args.FileOutput(args.save_matches, "wt") as fp:
             sourmash.save_signatures(keep, fp)


### PR DESCRIPTION
adjust thresholds and add --scaled argument, in order to support higher-resolution signatures (for protein) and smaller matches (virus).
