### PR TITLE
[MRG] Fix abundance calculations

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -39,7 +39,7 @@ PREFETCH_MEMORY = float(config.get('prefetch_memory', '100e9'))
 def make_param_str(ksizes, scaled):
     ks = [ f'k={k}' for k in ksizes ]
     ks = ",".join(ks)
-    return f"{ks},scaled={scaled}"
+    return f"{ks},scaled={scaled},abund"
 
 try:
     os.mkdir('genbank_genomes/')
@@ -356,7 +356,7 @@ rule count_trimmed_reads_wc:
                       }}' > {output.report}
     """
 
-# map abundtrim reads and producing a bam
+# map abundtrim reads and produce a bam
 rule minimap_wc:
     input:
         query = ancient("genbank_genomes/{acc}_genomic.fna.gz"),
@@ -382,7 +382,7 @@ rule bam_to_fastq_wc:
     """
 
 # get per-base depth information from BAM
-rule bam_to_depth_Wc:
+rule bam_to_depth_wc:
     input:
         bam = outdir + "/{dir}/{bam}.bam",
     output:

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -3,6 +3,7 @@ import pytest
 import tempfile
 import shutil
 import os
+import sourmash
 
 from genome_grist.__main__ import run_snakemake
 from . import pytest_utils as utils
@@ -48,7 +49,12 @@ def test_smash_sig():
     )
     assert status == 0
 
-    assert os.path.exists(f"{_tempdir}/sigs/HSMA33MX-subset.abundtrim.sig")
+    output_sig = f"{_tempdir}/sigs/HSMA33MX-subset.abundtrim.sig"
+    assert os.path.exists(output_sig)
+    sigs = list(sourmash.load_file_as_signatures(output_sig))
+    assert len(sigs) == 3
+    for s in sigs:
+        assert s.minhash.track_abundance
 
 
 @pytest.mark.dependency(depends=["test_smash_sig"])


### PR DESCRIPTION
Fixes https://github.com/dib-lab/genome-grist/issues/45, which was caused by dropping track-abundance from signature calculations by mistake when switch to using `sourmash sketch` from `sourmash compute` 🤦 .