### PR TITLE
use fastp instead of trimmomatic

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -279,7 +279,7 @@ rule trim_adapters_wc:
     shell: """
         fastp --in1 {input.r1} --in2 {input.r2} \
              --detect_adapter_for_pe  --qualified_quality_phred 4 \
-             --length_required 31 --correction \
+             --length_required 25 --correction \
              --json {output.json} --html {output.html} \
              --low_complexity_filter --stdout > {output.interleaved}
     """
@@ -297,7 +297,7 @@ rule trim_unpaired_adapters_wc:
         fastp --in1 {input.unp} --out1 {output.unp} \
             --detect_adapter_for_se  --qualified_quality_phred 4 \
             --low_complexity_filter \
-            --length_required 31 --correction \
+            --length_required 25 --correction \
             --json {output.json} --html {output.html}
     """
 

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -273,8 +273,8 @@ rule trim_adapters_wc:
         r2 = ancient(outdir + "/raw/{sample}_2.fastq.gz"),
     output:
         interleaved = protected(outdir + '/trim/{sample}.trim.fq.gz'),
-        json=outdir + "/raw/{sample}.trim.json",
-        html=outdir + "/raw/{sample}.trim.html",
+        json=outdir + "/trim/{sample}.trim.json",
+        html=outdir + "/trim/{sample}.trim.html",
     conda: 'env/trim.yml'
     threads: 16
     shell: """

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -272,10 +272,6 @@ rule trim_adapters_wc:
         r1 = ancient(outdir + "/raw/{sample}_1.fastq.gz"),
         r2 = ancient(outdir + "/raw/{sample}_2.fastq.gz"),
     output:
-        #r1 = protected(outdir + '/trim/{sample}_R1.trim.fq.gz'),
-        #r2 = protected(outdir + '/trim/{sample}_R2.trim.fq.gz'),
-        #o1 = protected(outdir + '/trim/{sample}_o1.trim.fq.gz'),
-        #o2 = protected(outdir + '/trim/{sample}_o2.trim.fq.gz'),
         interleaved = protected(outdir + '/trim/{sample}.trim.fq.gz'),
         json=outdir + "/raw/{sample}.trim.json",
         html=outdir + "/raw/{sample}.trim.html",
@@ -287,8 +283,6 @@ rule trim_adapters_wc:
              --json {output.json} --html {output.html} \
              --low_complexity_filter --stdout > {output.interleaved}
     """
-             #--out1 {output.r1} --out2 {output.r2} \ # to write non-interleaved PE files
-             #--unpaired1 {output.o1} --unpaired2 {output.o2} \ # to write unpaired reads that pass filter
 
 # adapter trimming for the singleton reads
 rule trim_unpaired_adapters_wc:
@@ -311,8 +305,6 @@ rule trim_unpaired_adapters_wc:
 rule kmer_trim_reads_wc:
     input: 
         interleaved = ancient(outdir + '/trim/{sample}.trim.fq.gz'),
-        #r1 = ancient(outdir + "/trim/{sample}_R1.trim.fq.gz"),
-        #r2 = ancient(outdir + "/trim/{sample}_R2.trim.fq.gz"),
     output:
         protected(outdir + "/abundtrim/{sample}.abundtrim.fq.gz")
     conda: 'env/trim.yml'
@@ -320,7 +312,6 @@ rule kmer_trim_reads_wc:
         mem_mb = int(ABUNDTRIM_MEMORY / 1e6),
     params:
         mem = ABUNDTRIM_MEMORY,
-        #interleave-reads.py {input.r1} {input.r2} |
     shell: """
             trim-low-abund.py -C 3 -Z 18 -M {params.mem} -V \
             {input.interleaved} -o {output} --gzip

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -266,50 +266,53 @@ rule smash_raw_reads_wc:
            --name 'rawreads:{wildcards.sample}' --track-abundance
     """
 
-rule download_adapters:
-    output: "inputs/adapters.fa"
-    shell: """
-        curl -L https://raw.githubusercontent.com/dib-lab/genome-grist/latest/inputs/adapters.fa -o {output}
-    """
-
 # adapter trimming
 rule trim_adapters_wc:
     input:
         r1 = ancient(outdir + "/raw/{sample}_1.fastq.gz"),
         r2 = ancient(outdir + "/raw/{sample}_2.fastq.gz"),
-        adapters = "inputs/adapters.fa"
     output:
-        r1 = protected(outdir + '/trim/{sample}_R1.trim.fq.gz'),
-        r2 = protected(outdir + '/trim/{sample}_R2.trim.fq.gz'),
-        o1 = protected(outdir + '/trim/{sample}_o1.trim.fq.gz'),
-        o2 = protected(outdir + '/trim/{sample}_o2.trim.fq.gz'),
+        #r1 = protected(outdir + '/trim/{sample}_R1.trim.fq.gz'),
+        #r2 = protected(outdir + '/trim/{sample}_R2.trim.fq.gz'),
+        #o1 = protected(outdir + '/trim/{sample}_o1.trim.fq.gz'),
+        #o2 = protected(outdir + '/trim/{sample}_o2.trim.fq.gz'),
+        interleaved = protected(outdir + '/trim/{sample}.trim.fq.gz'),
+        json=outdir + "/raw/{sample}.trim.json",
+        html=outdir + "/raw/{sample}.trim.html",
     conda: 'env/trim.yml'
     shell: """
-        trimmomatic PE {input.r1} {input.r2} \
-             {output.r1} {output.o1} {output.r2} {output.o2} \
-             ILLUMINACLIP:{input.adapters}:2:0:15 MINLEN:25  \
-             LEADING:2 TRAILING:2 SLIDINGWINDOW:4:2
+        fastp --in1 {input.r1} --in2 {input.r2} \
+             --detect_adapter_for_pe  --qualified_quality_phred 4 \
+             --length_required 31 --correction \
+             --json {output.json} --html {output.html} \
+             --low_complexity_filter --stdout > {output.interleaved}
     """
+             #--out1 {output.r1} --out2 {output.r2} \ # to write non-interleaved PE files
+             #--unpaired1 {output.o1} --unpaired2 {output.o2} \ # to write unpaired reads that pass filter
 
 # adapter trimming for the singleton reads
 rule trim_unpaired_adapters_wc:
     input:
         unp = ancient(outdir + "/raw/{sample}_unpaired.fastq.gz"),
-        adapters = "inputs/adapters.fa"
     output:
         unp = protected(outdir + '/trim/{sample}_unpaired.trim.fq.gz'),
+        json = protected(outdir + '/trim/{sample}_unpaired.trim.json'),
+        html = protected(outdir + '/trim/{sample}_unpaired.trim.html'),
     conda: 'env/trim.yml'
     shell: """
-        trimmomatic SE {input.unp} {output.unp} \
-             ILLUMINACLIP:{input.adapters}:2:0:15 MINLEN:25  \
-             LEADING:2 TRAILING:2 SLIDINGWINDOW:4:2
+        fastp --in1 {input.unp} --out1 {output.unp} \
+            --detect_adapter_for_se  --qualified_quality_phred 4 \
+            --low_complexity_filter \
+            --length_required 31 --correction \
+            --json {output.json} --html {output.html}
     """
 
 # k-mer abundance trimming
 rule kmer_trim_reads_wc:
     input: 
-        r1 = ancient(outdir + "/trim/{sample}_R1.trim.fq.gz"), 
-        r2 = ancient(outdir + "/trim/{sample}_R2.trim.fq.gz"),
+        interleaved = ancient(outdir + '/trim/{sample}.trim.fq.gz'),
+        #r1 = ancient(outdir + "/trim/{sample}_R1.trim.fq.gz"),
+        #r2 = ancient(outdir + "/trim/{sample}_R2.trim.fq.gz"),
     output:
         protected(outdir + "/abundtrim/{sample}.abundtrim.fq.gz")
     conda: 'env/trim.yml'
@@ -317,10 +320,10 @@ rule kmer_trim_reads_wc:
         mem_mb = int(ABUNDTRIM_MEMORY / 1e6),
     params:
         mem = ABUNDTRIM_MEMORY,
+        #interleave-reads.py {input.r1} {input.r2} |
     shell: """
-        interleave-reads.py {input.r1} {input.r2} | 
-            trim-low-abund.py -C 3 -Z 18 -M {params.mem} -V - \
-               -o {output} --gzip
+            trim-low-abund.py -C 3 -Z 18 -M {params.mem} -V \
+            {input.interleaved} -o {output} --gzip
     """
 
 # count k-mers

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -276,12 +276,13 @@ rule trim_adapters_wc:
         json=outdir + "/raw/{sample}.trim.json",
         html=outdir + "/raw/{sample}.trim.html",
     conda: 'env/trim.yml'
+    threads: 16
     shell: """
         fastp --in1 {input.r1} --in2 {input.r2} \
              --detect_adapter_for_pe  --qualified_quality_phred 4 \
-             --length_required 25 --correction \
+             --length_required 25 --correction --thread {threads} \
              --json {output.json} --html {output.html} \
-             --low_complexity_filter --stdout > {output.interleaved}
+             --low_complexity_filter --stdout | gzip -9 > {output.interleaved}
     """
 
 # adapter trimming for the singleton reads
@@ -292,11 +293,12 @@ rule trim_unpaired_adapters_wc:
         unp = protected(outdir + '/trim/{sample}_unpaired.trim.fq.gz'),
         json = protected(outdir + '/trim/{sample}_unpaired.trim.json'),
         html = protected(outdir + '/trim/{sample}_unpaired.trim.html'),
+    threads: 16
     conda: 'env/trim.yml'
     shell: """
         fastp --in1 {input.unp} --out1 {output.unp} \
             --detect_adapter_for_se  --qualified_quality_phred 4 \
-            --low_complexity_filter \
+            --low_complexity_filter --thread {threads} \
             --length_required 25 --correction \
             --json {output.json} --html {output.html}
     """

--- a/genome_grist/conf/env/trim.yml
+++ b/genome_grist/conf/env/trim.yml
@@ -4,5 +4,5 @@ channels:
  - defaults
 dependencies:
  - khmer=3.0.0a
- - trimmomatic=0.39
+ - fastp=0.20.1
  - seqtk=1.3


### PR DESCRIPTION
Benefits:
  - don't need to choose or download adapters (detected automatically!)
  - outputs interleaved files!  (can output pe if you want)
  - doesn't need to output unpaired files from pe (can output if you want)

Optional Features (I included, but can remove it you want) --
  - optional low complexity filter (https://github.com/OpenGene/fastp#low-complexity-filter)
>Low complexity filter is disabled by default, and you can enable it by -y or --low_complexity_filter. The complexity is defined as the percentage of base that is different from its next base (base[i] != base[i+1]). For example:

>#### a 51-bp sequence, with 3 bases that is different from its next base
>seq = 'AAAATTTTTTTTTTTTTTTTTTTTTGGGGGGGGGGGGGGGGGGGGGGCCCC'
>complexity = 3/(51-1) = 6%
>The threshold for low complexity filter can be specified by -Y or --complexity_threshold. It's range should be 0~100, and its default value is 30, which means 30% complexity is required.

  - optional PE read correction (https://github.com/OpenGene/fastp#base-correction-for-pe-data)
>fastp perform overlap analysis for PE data, which try to find an overlap of each pair of reads. If an proper overlap is found, it can correct mismatched base pairs in overlapped regions of paired end reads, if one base is with high quality while the other is with ultra low quality. If a base is corrected, the quality of its paired base will be assigned to it so that they will share the same quality.  

>This function is not enabled by default, specify -c or --correction to enable it. This function is based on overlapping detection, which has adjustable parameters overlap_len_require (default 30), overlap_diff_limit (default 5) and overlap_diff_limit_percent (default 20%). Please note that the reads should meet these three conditions simultaneously.

I couldn't resist making this PR. Sorry? Here's a puppy!