### PR TITLE
[MRG] Install mamba and use sourmash 4.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,12 @@
+name: grist
 channels:
  - conda-forge
  - bioconda
  - defaults
 dependencies:
+ - mamba
  - minimap2=2.17
  - samtools=1.10
  - screed>=1.0.5,<2
  - pip:
-   - sourmash>=4.0.0rc1,<5
+   - sourmash>=4,<5

--- a/genome_grist/conf/env/sourmash.yml
+++ b/genome_grist/conf/env/sourmash.yml
@@ -8,4 +8,4 @@ dependencies:
  - pip
  - pip:
    - git+https://github.com/dib-lab/genome-grist.git#egg=genome-grist
-   - sourmash>=4.0.0rc1,<5
+   - sourmash>=4,<5


### PR DESCRIPTION
Closes #73, I think?

- adds mamba to `environment yml` 
- update sourmash to 4.x (`environment.yml`; `genome_grist/conf/env/sourmash.yml`)

Note: this is just one way to solve #73. 
Alternatives:
- handle via `pip` in `setup.py`
- install `mamba` in the `test.yml` workflow

Happy to change to whatever option you prefer.