### PR TITLE
[MRG] switch to using zipfile outputs for prefetch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ channels:
 dependencies:
  - mamba
  - screed>=1.0.5,<2
- - sourmash>=4.1,<5
+ - sourmash>=4.1.1,<5

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -106,7 +106,7 @@ rule smash_reads:
 
 rule search_genbank:
     input:
-        expand(outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+        expand(outdir + "/genbank/{sample}.x.genbank.prefetch.zip",
                sample=SAMPLES)
 
 rule summarize_sample_info:
@@ -589,7 +589,7 @@ rule sourmash_prefetch_gather_wc:
         sig = outdir + "/sigs/{sample}.abundtrim.sig",
         db = SOURMASH_DB_LIST,
     output:
-        matches = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+        matches = outdir + "/genbank/{sample}.x.genbank.prefetch.zip",
     resources:
         mem_mb=int(PREFETCH_MEMORY / 1e3)
     conda: "env/sourmash.yml"
@@ -611,11 +611,11 @@ rule split_query_known_unknown_wc:
     """
     input:
         sig = outdir + "/sigs/{sample}.abundtrim.sig",
-        prefetch = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+        prefetch = outdir + "/genbank/{sample}.x.genbank.prefetch.zip",
     output:
         known = outdir + "/genbank/{sample}.x.genbank.known.sig",
         unknown = outdir + "/genbank/{sample}.x.genbank.unknown.sig",
-        report = outdir + "/genbank/{sample}.abundtrim.fq.gz.prefetch.sig.report.txt",
+        report = outdir + "/genbank/{sample}.abundtrim.fq.gz.prefetch.zip.report.txt",
     conda: "env/sourmash.yml"
     params:
         ksize = SOURMASH_DB_KSIZE,
@@ -630,7 +630,7 @@ rule split_query_known_unknown_wc:
 rule sourmash_gather_wc:
     input:
         known = outdir + "/genbank/{sample}.x.genbank.known.sig",
-        db = outdir + "/genbank/{sample}.x.genbank.prefetch.sig",
+        db = outdir + "/genbank/{sample}.x.genbank.prefetch.zip",
     output:
         csv = outdir + "/genbank/{sample}.x.genbank.gather.csv",
         matches = outdir + "/genbank/{sample}.x.genbank.matches.sig",
@@ -693,7 +693,7 @@ rule summarize_reads_info_wc:
     input:
         kmers = outdir + "/abundtrim/{sample}.abundtrim.fq.gz.kmer-report.txt",
         reads = outdir + "/abundtrim/{sample}.abundtrim.fq.gz.reads-report.txt",
-        sigs = outdir + "/genbank/{sample}.abundtrim.fq.gz.prefetch.sig.report.txt",
+        sigs = outdir + "/genbank/{sample}.abundtrim.fq.gz.prefetch.zip.report.txt",
     output:
         outdir + '/{sample}.info.yaml',
     run:

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -590,6 +590,7 @@ rule sourmash_prefetch_gather_wc:
         db = SOURMASH_DB_LIST,
     output:
         matches = outdir + "/genbank/{sample}.x.genbank.prefetch.zip",
+        csv = outdir + "/genbank/{sample}.x.genbank.prefetch.csv",
     resources:
         mem_mb=int(PREFETCH_MEMORY / 1e3)
     conda: "env/sourmash.yml"
@@ -601,7 +602,8 @@ rule sourmash_prefetch_gather_wc:
         echo "DB is {input.db}"
         sourmash prefetch {input.sig} {input.db} \
           --save-matches {output.matches} -k {params.ksize} \
-          --threshold-bp={params.threshold_bp} {params.moltype}
+          --threshold-bp={params.threshold_bp} {params.moltype} \
+          -o {output.csv}
     """
 
 # run sourmash search x genbank and find anything matching.

--- a/genome_grist/conf/env/sourmash.yml
+++ b/genome_grist/conf/env/sourmash.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  - python=3.7
  - screed
- - sourmash>=4.1,<5
+ - sourmash>=4.1.1,<5
  - pip
  - pip:
    - git+https://github.com/dib-lab/genome-grist.git#egg=genome-grist

--- a/genome_grist/conf/env/sra.yml
+++ b/genome_grist/conf/env/sra.yml
@@ -4,5 +4,5 @@ channels:
  - bioconda
  - defaults
 dependencies:
- - sra-tools=2.11.0
+ - sra-tools=2.10.0
  - seqtk=1.3

--- a/genome_grist/gather_split.py
+++ b/genome_grist/gather_split.py
@@ -44,7 +44,7 @@ def main():
         notify(f"Downsampling query from scaled={query_mh.scaled} to {scaled}")
         query_mh = query_mh.downsample(scaled=int(scaled))
 
-    unknown_mh = copy.copy(query_mh)
+    unknown_mh = query_mh.to_mutable()
 
     notify(f"Loaded {len(query_mh.hashes)} hashes from '{args.query_file}'")
 

--- a/tests/test-data/HSMA33MX.conf
+++ b/tests/test-data/HSMA33MX.conf
@@ -1,4 +1,4 @@
-sample: HSMA33MX
+sample: SRR5950647
 outdir: outputs.test.HSMA33MX
 sourmash_database_glob_pattern: tests/test-data/HSMA33MX-subset.x.genbank.matches.sig
 metagenome_trim_memory: 1e9


### PR DESCRIPTION
This PR switches to using the `.zip` output format for prefetch, which should require less memory (among other things).

While I'm at it, I upgraded requirements to sourmash v4.1.1, which was just released.

Also, here I downgrade sra-tools to 2.10.0, because 2.11.0 core dumps with an unhandled exception on my Mac laptop. This may be because [of the vdb-config confusion](https://github.com/ncbi/sra-tools/issues/77#issuecomment-635478745), or may not. 🤷  (I suspect the issue is that my `~/.ncbi/user-settings.mkfg` file, created by vdb-config, is out of date. But I decline to spend any more time on it for now!)