### PR TITLE
[MRG] change default targets and update help docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,11 @@ clean-test:
 	rm -fr outputs.test.HSMA33MX/
 
 test:
-	genome-grist run tests/test-data/HSMA33MX.conf summarize make_sgc_conf -j 8 -p
-	genome-grist run tests/test-data/HSMA33MX.conf summarize make_sgc_conf -j 8 -p
+	genome-grist run tests/test-data/HSMA33MX.conf summarize_mapping make_sgc_conf -j 8 -p
+	genome-grist run tests/test-data/HSMA33MX.conf summarize_mapping make_sgc_conf -j 8 -p
 
 flakes:
 	flake8 --ignore=E501 genome_grist/ tests/
 
 black:
 	black .
-

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Notes:
 
 Execute:
 ```
-genome-grist run conf-tutorial.yml summarize
+genome-grist run conf-tutorial.yml summarize_mapping
 ```
 
 This will perform the following steps:
@@ -68,9 +68,7 @@ This will perform the following steps:
 * perform a `sourmash gather` against the specified database (target `gather_genbank`).
 * download the matching genomes from GenBank into `genbank_genomes/` (target `download_matching_genomes`).
 * map the metagenome reads to the various genomes (target `map_reads`).
-* produce a summary notebook (target `summarize`).
-
-The default target is `gather_genbank`, and you can put one or more targets on the command line as above with `summarize`.
+* produce a summary notebook (target `summarize_mapping`).
 
 ## Output files
 
@@ -98,19 +96,24 @@ Please see [the genome-grist Snakefile](https://github.com/dib-lab/genome-grist/
 
 ## Additional targets
 
-The default target is `summarize`, for now.
+Recommended targets:
 
-- `download_reads` - download the metagenome(s)
-- `trim_reads` - trim the raw reads
-- `smash_reads` - build sourmash signatures for the raw reads
-- `summarize_sample_info` - summarize read number and distinct k-mers
-- `gather_genbank` - run a `gather` against the database
-- `summarize_gather` - summarize the `gather` output
-- `download_matching_genomes` - download all matching GenBank genomes
-- `map_reads` - map the metagenome reads to the matching GenBank genomes
-- `summarize` - build a combined summary report of mapping and `gather`
-- `build_consensus` - build a consensus genome from the mapping
-- `make_sgc_conf` - make a config file for spacegraphcats based on `gather`
+ * summarize_gather - produce summary reports on metagenome composition
+ * summarize_mapping - produce summary reports on k-mer and read mapping
+
+Note, 'summarize_mapping' includes 'summarize_gather'; reports will be
+in {{outdir}}/reports, where 'outdir' is specified in the config file.
+
+Additional intermediate targets:
+
+ * download_reads - download SRA metagenomes specified in conf file
+ * trim_reads - do basic read trimming/adapter removal for metagenome reads
+ * smash_reads - create sourmash signatures from metagenome reads
+ * summarize_sample_info - build a info.yaml summary file for each metagenome
+ * gather_genbank - run 'sourmash gather' on metagenomes against Genbank
+ * download_matching_genomes - download all matching Genbank genomes
+ * map_reads - map all metagenome reads to Genbank genomes
+ * make_sgc_conf - make a spacegraphcats config file
 
 ## Other information
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
  - defaults
 dependencies:
  - mamba
- - snakemake-minimal=6.4.1
+ - snakemake-minimal=6.5.1
  - click>=7,<8
  - lxml==4.6.1
  - pandas>1,<2

--- a/genome_grist/__main__.py
+++ b/genome_grist/__main__.py
@@ -114,7 +114,9 @@ def cli():
 @click.argument("snakemake_args", nargs=-1)
 def run(configfile, snakemake_args, no_use_conda, verbose, outdir, help):
     "execute genome-grist workflow (using snakemake underneath)"
-    if help or not snakemake_args:
+    targets = [ arg for arg in snakemake_args if not arg.startswith('-') ]
+    if help or not targets:
+        #CTB: note, this should match what's in README, please :)
         print(f"""
 This is genome-grist v{version}.
 
@@ -122,22 +124,28 @@ Usage:
 
    genome-grist run <conf file> <target> [ <target 2>... ] [ <snakemake args> ]
 
-Possible targets:
+Recommended targets:
+
+ * summarize_gather - produce summary reports on metagenome composition
+ * summarize_mapping - produce summary reports on k-mer and read mapping
+
+Note, 'summarize_mapping' includes 'summarize_gather'; reports will be
+in {{outdir}}/reports, where 'outdir' is specified in the config file.
+
+Additional intermediate targets:
 
  * download_reads - download SRA metagenomes specified in conf file
- * trim_reads - do basic read trimming/adapter removal
- * smash_reads - create sourmash signatures from reads
- * summarize_sample_info - ???
- * gather_genbank - run 'sourmash gather' on metagenome against Genbank
- * download_matching_genomes - download all matching Genbank genomes.
- * map_reads - map all metagenome reads to Genbank genomes.
- * summarize - produce summary reports on k-mer and read mapping
- * build_consensus - XXX
+ * trim_reads - do basic read trimming/adapter removal for metagenome reads
+ * smash_reads - create sourmash signatures from metagenome reads
+ * summarize_sample_info - build a info.yaml summary file for each metagenome
+ * gather_genbank - run 'sourmash gather' on metagenomes against Genbank
+ * download_matching_genomes - download all matching Genbank genomes
+ * map_reads - map all metagenome reads to Genbank genomes
  * make_sgc_conf - make a spacegraphcats config file
 
 Please see https://github.com/dib-lab/genome-grist for quickstart docs.
 
-Please ask questions at https://github.com/dib-lab/genome-grist/issues!
+Please post questions at https://github.com/dib-lab/genome-grist/issues!
 """)
         sys.exit(0)
 

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -75,9 +75,9 @@ wildcard_constraints:
     sample='[a-zA-Z0-9._]+'                   # should be everything but /
 
 rule all:
-    input:
-        expand(f'{outdir}/reports/report-{{sample}}.html',
-               sample=SAMPLES)
+    run:
+        print("\n\n** Please see documentation for possible targets. **\n\n",
+              file=sys.stderr)
 
 rule download_reads:
     input:
@@ -180,9 +180,11 @@ rule build_consensus:
         Checkpoint_GatherResults(outdir + f"/minimap/{{sample}}.x.{{acc}}.consensus.fa.gz"),
         Checkpoint_GatherResults(outdir + f"/leftover/{{sample}}.x.{{acc}}.consensus.fa.gz"),
 
-rule summarize:
+rule summarize_mapping:
     input:
         expand(f'{outdir}/reports/report-{{sample}}.html',
+               sample=SAMPLES),
+        expand(f'{outdir}/reports/report-gather-{{sample}}.html',
                sample=SAMPLES)
 
 rule make_sgc_conf:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "pytest-runner",
     ],
     use_scm_version={"write_to": "genome_grist/version.py"},
-    install_requires=["snakemake==6.4.1", "click>=7,<8", "lxml==4.6.1",
+    install_requires=["snakemake==6.5.1", "click>=7,<8", "lxml==4.6.1",
                       "pandas>1,<2"],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR:
* changes `summarize` to `summarize_mapping`, in honor of the new `summarize_gather`;
* fixes a problem in the `run` command line where providing options like `-n` prevented help from being output;
* updates snakemake version to 6.5.1 to avoid a `KeyError` problem having to do with checkpoints;

Fixes https://github.com/dib-lab/genome-grist/issues/96

Ready for review & merge @hehouts 

(note, the tests won't pass, but that's ok for now.)
