### PR TITLE
[MRG] update to use ::prefetch metatype for picklist

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -737,7 +737,7 @@ rule sourmash_gather_wc:
     shell: """
         sourmash gather {input.known} {input.db} -o {output.csv} \
           --threshold-bp {params.threshold_bp} \
-          --picklist {input.picklist}:match_md5:md5short \
+          --picklist {input.picklist}::prefetch \
           --save-matches {output.matches} > {output.out}
     """
 

--- a/genome_grist/conf/env/sourmash.yml
+++ b/genome_grist/conf/env/sourmash.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  - python=3.7
  - screed
- - sourmash>=4.2.0,<5
+ - sourmash>=4.2.1,<5
  - pip
  - pip:
    - git+https://github.com/dib-lab/genome-grist.git#egg=genome-grist


### PR DESCRIPTION
sourmash v4.2.1 contains the `prefetch` picklist type added in https://github.com/sourmash-bio/sourmash/pull/1660. This PR changes genome-grist to use that.
