### PR TITLE
[MRG] Fix README Tutorial Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -L https://osf.io/4n3m5/download -o gtdb-r95.nucleotide-k31-scaled1000.sbt.
 Put the following in a config file named `conf-tutorial.yml`:
 ```
 sample:
-- HSMA33MX
+- SRR5950647
 outdir: outputs.tutorial/
 metagenome_trim_memory: 1e9
 sourmash_database_glob_pattern: gtdb-r95.nucleotide-k31-scaled1000.sbt.zip

--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -778,29 +778,29 @@ rule make_combined_info_csv:
 
 # download actual genomes!
 rule download_matching_genome_wc:
-     input:
-         csvfile = ancient('genbank_genomes/{acc}.info.csv')
-     output:
-         genome = "genbank_genomes/{acc}_genomic.fna.gz"
-     run:
-         with open(input.csvfile, 'rt') as infp:
-             r = csv.DictReader(infp)
-             rows = list(r)
-             assert len(rows) == 1
-             row = rows[0]
-             acc = row['acc']
-             assert wildcards.acc.startswith(acc)
-             url = row['genome_url']
-             name = row['ncbi_tax_name']
+    input:
+        csvfile = ancient('genbank_genomes/{acc}.info.csv')
+    output:
+        genome = "genbank_genomes/{acc}_genomic.fna.gz"
+    run:
+        with open(input.csvfile, 'rt') as infp:
+            r = csv.DictReader(infp)
+            rows = list(r)
+            assert len(rows) == 1
+            row = rows[0]
+            acc = row['acc']
+            assert wildcards.acc.startswith(acc)
+            url = row['genome_url']
+            name = row['ncbi_tax_name']
 
-             print(f"downloading genome for acc {acc}/{name} from NCBI...",
-                   file=sys.stderr)
-             with open(output.genome, 'wb') as outfp:
-                 with urllib.request.urlopen(url) as response:
-                     content = response.read()
-                     outfp.write(content)
-                     print(f"...wrote {len(content)} bytes to {output.genome}",
-                           file=sys.stderr)
+            print(f"downloading genome for acc {acc}/{name} from NCBI...",
+                file=sys.stderr)
+            with open(output.genome, 'wb') as outfp:
+                with urllib.request.urlopen(url) as response:
+                    content = response.read()
+                    outfp.write(content)
+                    print(f"...wrote {len(content)} bytes to {output.genome}",
+                        file=sys.stderr)
 
 
 # summarize_reads_info


### PR DESCRIPTION
Fixes #108 

I don't know why `fasterq-dump` can't process the **experiment name**, but the **Run ID** works as expected.

Experiment: https://www.ncbi.nlm.nih.gov/sra/?term=HSMA33MX
Run: https://trace.ncbi.nlm.nih.gov/Traces/sra/?run=SRR5950647

---

To test:

```
fasterq-dump HSMA33MX -p --split-files ## Will fail
fasterq-dump SRR5950647 -p --split-files ## Will work
```