### PR TITLE
[MRG] make the ipython kernel step depend on the papermill conda environment

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -552,6 +552,8 @@ rule smash_abundtrim_wc:
 
 # configure ipython kernel for papermill
 rule set_kernel:
+    input:
+        srcdir('env/papermill.yml')
     output:
         touch(f"{outdir}/.kernel.set")
     conda: 'env/papermill.yml'


### PR DESCRIPTION
This PR runs the kernel setting step within the papermill conda environment whenever the `conf/env/papermill.yml` file is changed.

This (potentially) fixes an error that @mr-eyes and I both ran into when fixing the conda papermill environment as part of https://github.com/dib-lab/genome-grist/pull/111/ - in brief, the kernel wasn't properly (re)set when the environment was updated.


