### PR TITLE
[MRG] compress output signatures

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -138,7 +138,7 @@ rule download_reads:
     input:
         expand(f"{outdir}/raw/{{sample}}_1.fastq.gz", sample=SAMPLES),
         expand(f"{outdir}/raw/{{sample}}_2.fastq.gz", sample=SAMPLES),
-        expand(f"{outdir}/raw/{{sample}}.raw.sig", sample=SAMPLES),
+        expand(f"{outdir}/raw/{{sample}}.raw.sig.gz", sample=SAMPLES),
 
 @toplevel
 rule trim_reads:
@@ -161,7 +161,7 @@ rule count_trimmed_reads:
 @toplevel
 rule smash_reads:
     input:
-        url_file = expand(f"{outdir}/sigs/{{sample}}.abundtrim.sig",
+        url_file = expand(f"{outdir}/sigs/{{sample}}.abundtrim.sig.gz",
                           sample=SAMPLES)
 
 @toplevel
@@ -473,7 +473,7 @@ rule smash_raw_reads_wc:
         r2 = ancient(outdir + "/raw/{sample}_2.fastq.gz"),
         unp = ancient(outdir + "/raw/{sample}_unpaired.fastq.gz"),
     output:
-        sig = outdir + "/raw/{sample}.raw.sig"
+        sig = outdir + "/raw/{sample}.raw.sig.gz"
     conda: "env/sourmash.yml"
     params:
         param_str = make_param_str(ksizes=SOURMASH_COMPUTE_KSIZES,
@@ -685,7 +685,7 @@ rule smash_abundtrim_wc:
     input:
         metagenome = ancient(outdir + "/abundtrim/{sample}.abundtrim.fq.gz"),
     output:
-        sig = outdir + "/sigs/{sample}.abundtrim.sig"
+        sig = outdir + "/sigs/{sample}.abundtrim.sig.gz"
     conda: "env/sourmash.yml"
     params:
         param_str = make_param_str(ksizes=SOURMASH_COMPUTE_KSIZES,
@@ -819,12 +819,12 @@ rule sourmash_prefetch_wc:
        Find all potentially relevant database matches for {wildcards.sample}
     """
     input:
-        sig = outdir + "/sigs/{sample}.abundtrim.sig",
+        sig = outdir + "/sigs/{sample}.abundtrim.sig.gz",
         db = SOURMASH_DB_LIST,
     output:
         csv = outdir + "/gather/{sample}.prefetch.csv",
-        known = outdir + "/gather/{sample}.known.sig",
-        unknown = outdir + "/gather/{sample}.unknown.sig",
+        known = outdir + "/gather/{sample}.known.sig.gz",
+        unknown = outdir + "/gather/{sample}.unknown.sig.gz",
     resources:
         mem_mb=int(PREFETCH_MEMORY / 1e3)
     conda: "env/sourmash.yml"
@@ -848,9 +848,9 @@ rule report_query_known_unknown_wc:
        Report on "known" and "unknown" hashes for {wildcards.sample}
     """
     input:
-        query = outdir + "/sigs/{sample}.abundtrim.sig",
-        known = outdir + "/gather/{sample}.known.sig",
-        unknown = outdir + "/gather/{sample}.unknown.sig",
+        query = outdir + "/sigs/{sample}.abundtrim.sig.gz",
+        known = outdir + "/gather/{sample}.known.sig.gz",
+        unknown = outdir + "/gather/{sample}.unknown.sig.gz",
     output:
         report = outdir + "/gather/{sample}.prefetch.report.txt",
     conda: "env/sourmash.yml"
@@ -869,12 +869,12 @@ rule sourmash_gather_wc:
        Run gather for {wildcards.sample}
     """
     input:
-        known = outdir + "/gather/{sample}.known.sig",
+        known = outdir + "/gather/{sample}.known.sig.gz",
         picklist = outdir + "/gather/{sample}.prefetch.csv",
         db = SOURMASH_DB_LIST,
     output:
         csv = outdir + "/gather/{sample}.gather.csv",
-        matches = outdir + "/gather/{sample}.matches.sig",
+        matches = outdir + "/gather/{sample}.matches.sig.gz",
         out = outdir + "/gather/{sample}.gather.out",
     conda: "env/sourmash.yml"
     params:

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -55,7 +55,7 @@ def test_smash_sig():
     )
     assert status == 0
 
-    output_sig = f"{_tempdir}/sigs/SRR5950647_subset.abundtrim.sig"
+    output_sig = f"{_tempdir}/sigs/SRR5950647_subset.abundtrim.sig.gz"
     assert os.path.exists(output_sig)
     sigs = list(sourmash.load_file_as_signatures(output_sig))
     assert len(sigs) == 3


### PR DESCRIPTION
For no good reason, the .sig files produced by genome-grist are not compressed, despite sourmash supporting it natively. This fixes that by putting a .gz suffix on everything.

Fixes https://github.com/dib-lab/genome-grist/issues/156
