### PR TITLE
[MRG] fix and adjust gather-based known/unknown reporting

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -913,7 +913,7 @@ rule sourmash_gather_wc:
        Run gather for {wildcards.sample}
     """
     input:
-        known = outdir + "/gather/{sample}.known.sig.gz",
+        sig = outdir + "/sigs/{sample}.abundtrim.sig.gz",
         picklist = outdir + "/gather/{sample}.prefetch.csv",
         db = SOURMASH_DB_LIST,
     output:
@@ -924,7 +924,7 @@ rule sourmash_gather_wc:
     params:
         threshold_bp = SOURMASH_DATABASE_THRESHOLD_BP,
     shell: """
-        sourmash gather {input.known} {input.db} -o {output.csv} \
+        sourmash gather {input.sig} {input.db} -o {output.csv} \
           --threshold-bp {params.threshold_bp} \
           --picklist {input.picklist}::prefetch \
           --save-matches {output.matches} > {output.out}


### PR DESCRIPTION
A long time ago, in a galaxy far, far away, we updated genome-grist to run gather only on the known bits of the metagenome signature - looks like it was in https://github.com/dib-lab/genome-grist/pull/29. Then we slowly updated things to use prefetch to calculate the known bits, and switched to using manifests, etc. etc. etc. And finally we fixed `sourmash gather` to do the split properly internally, over in https://github.com/sourmash-bio/sourmash/pull/1613. But we never updated genome-grist, so all of the genome-grist `gather` output files contained the wrong "% known" in the output!

This PR fixes that; the gather output will now contain the correct fraction of the sample that is (un)known.

Fixes https://github.com/dib-lab/genome-grist/issues/163