### PR TITLE
[MRG] Speed up `copy_local_genomes.py` with symbolic links

### DIFF
--- a/doc/configuring.md
+++ b/doc/configuring.md
@@ -242,7 +242,7 @@ curl -L https://osf.io/ckbq3/download -o outputs.private/abundtrim/podar.abundtr
 and then confirm that the config file `conf-private.yml` has the following content:
 
 ```yaml
-sample:
+samples:
 - podar
 
 outdir: outputs.private/

--- a/doc/configuring.md
+++ b/doc/configuring.md
@@ -242,7 +242,7 @@ curl -L https://osf.io/ckbq3/download -o outputs.private/abundtrim/podar.abundtr
 and then confirm that the config file `conf-private.yml` has the following content:
 
 ```yaml
-samples:
+sample:
 - podar
 
 outdir: outputs.private/

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -63,10 +63,9 @@ def main():
                 fp.read(1)
                 is_gzipped = True
 
-        destfile = os.path.join(args.output_directory, f"{ident}_genomic.fna")
-        destfile = f"{destfile}.gz" if is_gzipped else destfile
+        destfile = os.path.join(args.output_directory, f"{ident}_genomic.fna.gz")
         
-        if args.sym:
+        if args.sym and is_gzipped:
             print(f"symbolic linking '{filename}' to '{destfile}'")
             _src = os.path.abspath(filename)
             _dst = os.path.abspath(destfile)

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -75,7 +75,7 @@ def main():
             _src = os.path.abspath(filename)
             _dst = os.path.abspath(destfile)
             if os.path.islink(_dst):
-                print(f"symlink {_dst} already exist, consider removing it first.", file= sys.stderr)
+                print(f"symlink {_dst} already exists, consider removing it first.", file=sys.stderr)
                 sys.exit(1)
             os.symlink(_src, _dst)
         elif is_gzipped:

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import gzip
 import contextlib
-from pathlib import Path
 
 def main():
     p = argparse.ArgumentParser()

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -20,7 +20,7 @@ def main():
     p.add_argument('--sym', required=False, action= 'store_true')
     args = p.parse_args()
     
-    # Create directories if not exist
+    # Create directory if does not exist
     try:
         os.makedirs(args.output_directory)
     except FileExistsError:

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -67,7 +67,7 @@ def main():
         
         
         if args.sym and not is_gzipped:
-            print(f"--sym option requires the Fasta files to be gzipped first.", file= sys.stderr)
+            print("--sym option requires the FASTA files to be already gzipped.", file=sys.stderr)
             sys.exit(1)
         
         if args.sym and is_gzipped:

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -68,7 +68,7 @@ def main():
         
         if args.sym and not is_gzipped:
             print("--sym option requires the FASTA files to be already gzipped.", file=sys.stderr)
-            sys.exit(1)
+            sys.exit(-1)
         
         if args.sym and is_gzipped:
             print(f"symbolic linking '{filename}' to '{destfile}'")

--- a/genome_grist/copy_local_genomes.py
+++ b/genome_grist/copy_local_genomes.py
@@ -65,6 +65,11 @@ def main():
 
         destfile = os.path.join(args.output_directory, f"{ident}_genomic.fna.gz")
         
+        
+        if args.sym and not is_gzipped:
+            print(f"--sym option requires the Fasta files to be gzipped first.", file= sys.stderr)
+            sys.exit(1)
+        
         if args.sym and is_gzipped:
             print(f"symbolic linking '{filename}' to '{destfile}'")
             _src = os.path.abspath(filename)


### PR DESCRIPTION
`genome_grist.copy_local_genomes` takes forever to copy and compress FASTA files. This PR resolves #138 by adding the command line option `--sym` to use symbolic links. `--sym` defaults to False, might be changed later after discussing the PR.

Also upgrading private genomes config file to the latest version in docs (`samples` instead of `sample`).