### PR TITLE
[MRG] fix local genomes config file in docs

### DIFF
--- a/doc/configuring.md
+++ b/doc/configuring.md
@@ -242,7 +242,7 @@ curl -L https://osf.io/ckbq3/download -o outputs.private/abundtrim/podar.abundtr
 and then confirm that the config file `conf-private.yml` has the following content:
 
 ```yaml
-sample:
+samples:
 - podar
 
 outdir: outputs.private/


### PR DESCRIPTION
This PR changes the docs config file `sample` parameter to `samples` to be compatible with the grist latest version.