### PR TITLE
[MRG] fix exit codes from genome-grist CLI

### DIFF
--- a/genome_grist/__main__.py
+++ b/genome_grist/__main__.py
@@ -155,7 +155,7 @@ Please post questions at https://github.com/dib-lab/genome-grist/issues!
         extra_args=snakemake_args,
         outdir=outdir,
     )
-    sys.exit(ret)
+    sys.exit(ret.returncode)
 
 
 # 'check' command
@@ -163,7 +163,7 @@ Please post questions at https://github.com/dib-lab/genome-grist/issues!
 @click.argument("configfile")
 def check(configfile):
     "check configuration"
-    sys.exit(run_snakemake(configfile, extra_args=["check"]))
+    sys.exit(run_snakemake(configfile, extra_args=["check"]).returncode)
 
 
 # 'showconf' command
@@ -171,7 +171,7 @@ def check(configfile):
 @click.argument("configfile")
 def showconf(configfile):
     "show full configuration"
-    sys.exit(run_snakemake(configfile, extra_args=["showconf"]))
+    sys.exit(run_snakemake(configfile, extra_args=["showconf"]).returncode)
 
 
 # 'info' command


### PR DESCRIPTION
In https://github.com/dib-lab/genome-grist/pull/195, I changed the return value of `run_snakemake` to be a `CompletedProcess` instance as returned by `subprocess.run(...)` [ref](https://docs.python.org/3/library/subprocess.html#subprocess.run). This broke the bits of the code that use `sys.exit(run_snakemake(...))` to signal success or failure on CLI execution.

This PR fixes the returncode to be the value of `CompletedProcess.returncode`.