### PR TITLE
[MRG] fix trim-low-abund ksize to match analysis ksize

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -607,8 +607,9 @@ rule kmer_trim_reads_wc:
         mem_mb = int(ABUNDTRIM_MEMORY / 1e6),
     params:
         mem = ABUNDTRIM_MEMORY,
+        ksize = SOURMASH_DB_KSIZE,
     shell: """
-            trim-low-abund.py -C 3 -Z 18 -M {params.mem} -V \
+        trim-low-abund.py -C 3 -Z 18 -M {params.mem} -k {params.ksize} -V \
             {input.interleaved} -o {output} --gzip
     """
 


### PR DESCRIPTION
Fixes https://github.com/dib-lab/genome-grist/issues/191
