### PR TITLE
[MRG] fix calculation of memory required for prefetch step.

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -42,6 +42,7 @@ if not base_tempdir:
     print(f"Could not create a temporary directory in any of {try_temp_locations}", file=sys.stderr)
     print("Please set 'tempdir' in the config.", file=sys.stderr)
     sys.exit(-1)
+print(f'base_tempdir: {base_tempdir}', file=sys.stderr)
 
 ABUNDTRIM_MEMORY = float(config.get('metagenome_trim_memory', '1e9'))
 
@@ -914,7 +915,7 @@ rule sourmash_prefetch_wc:
         known = touch(outdir + "/gather/{sample}.known.sig.zip"),
         unknown = touch(outdir + "/gather/{sample}.unknown.sig.zip"),
     resources:
-        mem_mb=int(PREFETCH_MEMORY / 1e3)
+        mem_mb=int(PREFETCH_MEMORY / 1e6)
     conda: "env/sourmash.yml"
     params:
         ksize = SOURMASH_DB_KSIZE,


### PR DESCRIPTION
This PR fixes the calculation of resources needed for sourmash prefetch, so that snakemake will correctly run more things in parallel when given the resources to do so.

(MB == 1 m == 1e6, not 1e3...)