### PR TITLE
[WIP] add code to support skipping genomes by ident

### DIFF
--- a/genome_grist/conf/Snakefile
+++ b/genome_grist/conf/Snakefile
@@ -94,6 +94,8 @@ def make_param_str(ksizes, scaled):
     ks = ",".join(ks)
     return f"{ks},scaled={scaled},abund"
 
+IGNORE_IDENTS = config.get('skip_genomes', [])
+
 ###
 #
 # print out unknown config variables...
@@ -262,6 +264,8 @@ class Checkpoint_GatherResults:
         genome_idents = []
         for row in load_gather_csv(gather_csv):
             ident = row['name'].split()[0]
+            if ident in IGNORE_IDENTS:
+                continue
             genome_idents.append(ident)
 
         return genome_idents


### PR DESCRIPTION
This is one way to fix the problem where GenBank genomes have been removed, which is causing problems - see https://github.com/dib-lab/genome-grist/issues/241.

The idea is that you add
```
skip_genomes:
- GCF_000020205.1
```

to your config file and it removes those from the gather results.

I'm not sure this is the right way to handle it but it does seem to be one easy way to do it, at least ;).