### PR TITLE
MRG: include Snakefile in pkg again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: all flakes black clean-test clean-gather test install
+.PHONY: all flakes black clean-test clean-gather test install dist
 
 all: clean-test test
+
+dist:
+	python -m build
 
 flakes:
 	flake8 --ignore=E501 genome_grist/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "genome-grist"
 description = "tools to support genome and metagenome analysis"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.11.3"
+version = "0.11.4"
 authors = [
   { name="C. Titus Brown" },
   { name="Luiz Irber" },
@@ -42,7 +42,7 @@ packages = ["genome_grist"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-genome_grist = ["Snakefile"]
+genome_grist = ["Snakefile", "env/*.yml"]
 
 [metadata]
 license = { text = "GNU Affero General Public License v3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ test = [
 
 [tool.setuptools]
 packages = ["genome_grist"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+genome_grist = ["Snakefile"]
 
 [metadata]
 license = { text = "GNU Affero General Public License v3" }


### PR DESCRIPTION
- v0.11.3 pip install was not including `Snakefile`
- add Snakefile as pkg data in `pyproject.toml`

This seems to fix on my end, and the `Snakefile` moved location in #313. The `env` folder also moved in #313, but it seems to be included in the install already.